### PR TITLE
Added the possiblity to activate stream from all MAV at the same time

### DIFF
--- a/communication/mavlink_communication.c
+++ b/communication/mavlink_communication.c
@@ -64,7 +64,7 @@ static void mavlink_communication_toggle_telemetry_stream(scheduler_t* scheduler
 	mavlink_request_data_stream_t request;
 	mavlink_msg_request_data_stream_decode(msg, &request);
 	
-	if ((request.target_system == scheduler->mavlink_stream->sysid)
+	if (((request.target_system == scheduler->mavlink_stream->sysid)||(request.target_system == MAV_SYS_ID_ALL))
 		&&(request.target_component == 0))
 	{
 		if ( scheduler->debug )


### PR DESCRIPTION
With the improvement of QGroundControl, we will be able to activate streams. We will be able to choose one or all the connected MAVs for activation. 
