### PR TITLE
Correction of drift behavior when auto_continue is set to zero and/or di...

### DIFF
--- a/control/navigation.c
+++ b/control/navigation.c
@@ -236,22 +236,17 @@ static void navigation_set_speed_command(float rel_pos[], navigation_t* navigati
 	
 	dir_desired_bf[2] = rel_pos[2];
 	
-	if (((navigation->state->mav_mode.GUIDED == GUIDED_ON)&&(navigation->state->mav_mode.AUTO == AUTO_OFF))||((maths_f_abs(rel_pos[X])<=1.0f)&&(maths_f_abs(rel_pos[Y])<=1.0f))||((maths_f_abs(rel_pos[X])<=5.0f)&&(maths_f_abs(rel_pos[Y])<=5.0f)&&(maths_f_abs(rel_pos[Z])>=3.0f)))
-	{
-		rel_heading = 0.0f;
-	}
-	else
-	{
-		rel_heading = maths_calc_smaller_angle(atan2(rel_pos[Y],rel_pos[X]) - navigation->position_estimator->local_position.heading);
-	}
-	
 	if ((mode.AUTO == AUTO_ON) && ((navigation->state->nav_plan_active&&(!navigation->stop_nav)&&(!navigation->auto_takeoff)&&(!navigation->auto_landing))||((navigation->state->mav_state == MAV_STATE_CRITICAL)&&(navigation->critical_behavior == FLY_TO_HOME_WP))))
 	{
+		rel_heading = maths_calc_smaller_angle(atan2(rel_pos[Y],rel_pos[X]) - navigation->position_estimator->local_position.heading);
+		
 		navigation->wpt_nav_controller.clip_max = navigation->cruise_speed;
 		v_desired = pid_control_update_dt(&navigation->wpt_nav_controller, (maths_center_window_2(4.0f * rel_heading) * norm_rel_dist), navigation->dt);
 	}
 	else
 	{
+		rel_heading = 0.0f;
+		
 		navigation->hovering_controller.clip_max = navigation->cruise_speed;
 		v_desired = pid_control_update_dt(&navigation->hovering_controller, (maths_center_window_2(4.0f * rel_heading) * norm_rel_dist), navigation->dt);
 	}


### PR DESCRIPTION
...fferent hold behavior (e.g. auto takeoff, landing, etc)

To test: 
- set two waypoints, with auto_continue to zero, and a desired heading in the direction of the next waypoint. 

It should not drift and try to get to the center of the waypoint.

No project specific file change. 
