### PR TITLE
Set point of speed controller can be set at startup

### DIFF
--- a/hal/pwm_servos.c
+++ b/hal/pwm_servos.c
@@ -210,7 +210,7 @@ void pwm_servos_write_to_hardware(const servos_t* servos)
 	}
 }
 
-void pwm_servos_set_speed_controller_set_point(const servos_t* servos)
+void pwm_servos_calibrate_esc(const servos_t* servos)
 {
 	int16_t i;
 	
@@ -222,7 +222,7 @@ void pwm_servos_set_speed_controller_set_point(const servos_t* servos)
 	}
 	
 	pwm_servos_write_to_hardware(&speed_controller);
-	delay_ms(4000);
+	delay_ms(2000);
 	servos_set_value_failsafe(&speed_controller);
 	pwm_servos_write_to_hardware(&speed_controller);
 }

--- a/hal/pwm_servos.h
+++ b/hal/pwm_servos.h
@@ -74,7 +74,7 @@ void pwm_servos_write_to_hardware(const servos_t* servos);
  *
  * \param servos				Pointer to a structure containing the servos' data
  */
-void pwm_servos_set_speed_controller_set_point(const servos_t* servos);
+void pwm_servos_calibrate_esc(const servos_t* servos);
 
 #ifdef __cplusplus
 	}


### PR DESCRIPTION
 just call pwm_servos_set_speed_controller_set_point(&central_data.servos); 
between servos_set_value_failsafe and pwm_servos_write_to_hardware():

```
// Init servos
    servos_init( &central_data.servos, &servos_default_config);

    pwm_servos_set_speed_controller_set_point(&central_data.servos);

    servos_set_value_failsafe( &central_data.servos );
    pwm_servos_write_to_hardware( &central_data.servos );
```

BE CAREFUL!!!!
DO NOT DO THIS IF THE SPEEDCONTROLLERS HAVE ALREADY BEEN POWERED (THEY ARE BEEPING DURING THE FLASH E.G. WITH THE ICE2 DEVICE) OTHERWISE MOTORS WILL START FULL THROTTLE

NEVER DO THIS WITH PROPELLERS ON!
