### PR TITLE
Add Madgwick attitude estimation filter

### DIFF
--- a/sensing/ahrs_madgwick.c
+++ b/sensing/ahrs_madgwick.c
@@ -57,11 +57,16 @@
 #include "quaternions.h"
 
 
-bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf_t* config, const imu_t* imu, ahrs_t* ahrs)
+bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf_t* config, imu_t* imu, ahrs_t* ahrs)
 {
 	// Init dependencies
 	ahrs_madgwick->imu 	= imu;
 	ahrs_madgwick->ahrs = ahrs;
+
+	// Init variables
+	ahrs_madgwick->ref_b[X] 	= 1.0f;
+	ahrs_madgwick->ref_b[Y] 	= 0.0f;
+	ahrs_madgwick->ref_b[Z] 	= 0.0f;
 
 	// Init ahrs structure
 	ahrs_madgwick->ahrs->qe.s = 1.0f;
@@ -89,8 +94,7 @@ bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf
 
 	// Init config
 	ahrs_madgwick->beta = config->beta;
-	
-
+	ahrs_madgwick->zeta = config->zeta;
 
 	// Notify success
 	print_util_dbg_print("[AHRS MADGWICK] Initialised.\r\n");
@@ -101,168 +105,216 @@ bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf
 
 void ahrs_madgwick_update(ahrs_madgwick_t* ahrs_madgwick)
 {
+	// ----
 	// Variables required for computation
-	float recipNorm;
-	float s0, s1, s2, s3;
-	float qDot1, qDot2, qDot3, qDot4;
-	float hx, hy;
-	float _2q0mx, _2q0my, _2q0mz, _2q1mx, _2bx, _2bz, _4bx, _4bz, _2q0, _2q1, _2q2, _2q3, _2q0q2, _2q2q3, q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
-	//quat_t q_enu;
-	//quat_t q_enu2ned = {.s=0, .v={0.7071f, 0.7071f, 0.0f}};
-	quat_t q_nwu;
-	quat_t q_nwu2ned = {.s=0, .v={1.0f, 0.0f, 0.0f}};
-
-	// // Get current attitude in ENU
-	// q_enu = quaternions_rotate(ahrs_madgwick->ahrs->qe, quaternions_inverse(q_enu2ned));
-	// float q0 = q_enu.s;
-	// float q1 = q_enu.v[X];
-	// float q2 = q_enu.v[Y];
-	// float q3 = q_enu.v[Z];
-
-	// // Get values from sensors in ENU
-	// float gy = ahrs_madgwick->imu->scaled_gyro.data[X];  
-	// float gx = ahrs_madgwick->imu->scaled_gyro.data[Y];
-	// float gz = -ahrs_madgwick->imu->scaled_gyro.data[Z];
-	// float ay = ahrs_madgwick->imu->scaled_accelero.data[X];
-	// float ax = ahrs_madgwick->imu->scaled_accelero.data[Y];
-	// float az = -ahrs_madgwick->imu->scaled_accelero.data[Z];
-	// float my = ahrs_madgwick->imu->scaled_compass.data[X];
-	// float mx = ahrs_madgwick->imu->scaled_compass.data[Y];
-	// float mz = -ahrs_madgwick->imu->scaled_compass.data[Z];
-
-	// Get current attitude in NWU
-	q_nwu = quaternions_rotate(ahrs_madgwick->ahrs->qe, quaternions_inverse(q_nwu2ned));
-	float q0 = q_nwu.s;
-	float q1 = q_nwu.v[X];
-	float q2 = q_nwu.v[Y];
-	float q3 = q_nwu.v[Z];
-
-	// Get values from sensors in NWU
-	float gx = ahrs_madgwick->imu->scaled_gyro.data[X];  
-	float gy = -ahrs_madgwick->imu->scaled_gyro.data[Y];
-	float gz = -ahrs_madgwick->imu->scaled_gyro.data[Z];
-	float ax = ahrs_madgwick->imu->scaled_accelero.data[X];
-	float ay = -ahrs_madgwick->imu->scaled_accelero.data[Y];
-	float az = -ahrs_madgwick->imu->scaled_accelero.data[Z];
-	// float mx = ahrs_madgwick->imu->scaled_compass.data[X];
-	// float my = -ahrs_madgwick->imu->scaled_compass.data[Y];
-	// float mz = -ahrs_madgwick->imu->scaled_compass.data[Z];
-	float mx = ahrs_madgwick->imu->scaled_compass.data[X];
-	float my = -ahrs_madgwick->imu->scaled_compass.data[Y];
-	float mz = -ahrs_madgwick->imu->scaled_compass.data[Z];
+	// ----
+	float recip_norm, norm; 													// vector norm
+	float q_dot_omega_1, q_dot_omega_2, q_dot_omega_3, q_dot_omega_4; 		// quaternion rate from gyroscopes elements
+	float f1, f2, f3, f4, f5, f6; 										// objective function elements
+	float J_11or24, J_12or23, J_13or22, J_14or21, J_32, J_33; 					// objective function Jacobian elements
+	float J_41, J_42, J_43, J_44, J_51, J_52, J_53, J_54, J_61, J_62, J_63, J_64; 
+	float qhat_dot_1, qhat_dot_2, qhat_dot_3, qhat_dot_4; 					// estimated direction of the gyroscope error
+	float w_err_x, w_err_y, w_err_z; 											// estimated direction of the gyroscope error (angular)
+	float h_x, h_y, h_z;														// computed flux in the earth frame
 
 	// Compute time since last update
-	float now 	= time_keeper_get_time(); 
-	float dt 	= now - ahrs_madgwick->ahrs->last_update;
+	float now = time_keeper_get_time(); 
+	float dt  = now - ahrs_madgwick->ahrs->last_update;
 
-	// Rate of change of quaternion from gyroscope
-	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
-	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
-	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
-	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+	// Get current attitude in NED
+	float q1 = ahrs_madgwick->ahrs->qe.s;
+	float q2 = ahrs_madgwick->ahrs->qe.v[X];
+	float q3 = ahrs_madgwick->ahrs->qe.v[Y];
+	float q4 = ahrs_madgwick->ahrs->qe.v[Z];
 
-	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
-	if( !((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) ) 
+	// Get values from sensors in NED
+	float wx = ahrs_madgwick->imu->scaled_gyro.data[X];  
+	float wy = ahrs_madgwick->imu->scaled_gyro.data[Y];
+	float wz = ahrs_madgwick->imu->scaled_gyro.data[Z];
+	float ax = ahrs_madgwick->imu->scaled_accelero.data[X];
+	float ay = ahrs_madgwick->imu->scaled_accelero.data[Y];
+	float az = ahrs_madgwick->imu->scaled_accelero.data[Z];
+	float mx = ahrs_madgwick->imu->scaled_compass.data[X];
+	float my = ahrs_madgwick->imu->scaled_compass.data[Y];
+	float mz = ahrs_madgwick->imu->scaled_compass.data[Z];
+
+	// Get current estimate of earth magnetic field orientation
+	float bx = ahrs_madgwick->ref_b[X];
+	float bz = ahrs_madgwick->ref_b[Z];
+
+	// Get current gyro bias estimate
+	float w_bx = ahrs_madgwick->imu->calib_gyro.bias[X] * ahrs_madgwick->imu->calib_gyro.scale_factor[X];
+	float w_by = ahrs_madgwick->imu->calib_gyro.bias[Y] * ahrs_madgwick->imu->calib_gyro.scale_factor[Y];
+	float w_bz = ahrs_madgwick->imu->calib_gyro.bias[Z] * ahrs_madgwick->imu->calib_gyro.scale_factor[Z];
+
+	// Compute feedback only if magnetometer measurement valid (avoids NaN in magnetometer normalisation)
+	if( (mx == 0.0f) && (my == 0.0f) && (mz == 0.0f) ) 
 	{
-		// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
-		if( !((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)) ) 
-		{
-			// Normalise accelerometer measurement
-			recipNorm = maths_fast_inv_sqrt(ax * ax + ay * ay + az * az);
-			ax *= recipNorm;
-			ay *= recipNorm;
-			az *= recipNorm;   
-
-			// Normalise magnetometer measurement
-			recipNorm = maths_fast_inv_sqrt(mx * mx + my * my + mz * mz);
-			mx *= recipNorm;
-			my *= recipNorm;
-			mz *= recipNorm;
-
-			// Auxiliary variables to avoid repeated arithmetic
-			_2q0mx = 2.0f * q0 * mx;
-			_2q0my = 2.0f * q0 * my;
-			_2q0mz = 2.0f * q0 * mz;
-			_2q1mx = 2.0f * q1 * mx;
-			_2q0 = 2.0f * q0;
-			_2q1 = 2.0f * q1;
-			_2q2 = 2.0f * q2;
-			_2q3 = 2.0f * q3;
-			_2q0q2 = 2.0f * q0 * q2;
-			_2q2q3 = 2.0f * q2 * q3;
-			q0q0 = q0 * q0;
-			q0q1 = q0 * q1;
-			q0q2 = q0 * q2;
-			q0q3 = q0 * q3;
-			q1q1 = q1 * q1;
-			q1q2 = q1 * q2;
-			q1q3 = q1 * q3;
-			q2q2 = q2 * q2;
-			q2q3 = q2 * q3;
-			q3q3 = q3 * q3;
-
-			// Reference direction of Earth's magnetic field
-			hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
-			hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
-			_2bx = sqrt(hx * hx + hy * hy);
-			_2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
-			_4bx = 2.0f * _2bx;
-			_4bz = 2.0f * _2bz;
-
-			// Gradient decent algorithm corrective step
-			s0 = -_2q2 * (2.0f * q1q3 - _2q0q2 - ax) + _2q1 * (2.0f * q0q1 + _2q2q3 - ay) - _2bz * q2 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q3 + _2bz * q1) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q2 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-			s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-			s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-			s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-			recipNorm = maths_fast_inv_sqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
-			s0 *= recipNorm;
-			s1 *= recipNorm;
-			s2 *= recipNorm;
-			s3 *= recipNorm;
-
-			// Apply feedback step
-			qDot1 -= ahrs_madgwick->beta * s0;
-			qDot2 -= ahrs_madgwick->beta * s1;
-			qDot3 -= ahrs_madgwick->beta * s2;
-			qDot4 -= ahrs_madgwick->beta * s3;				
-		}
+		return;
 	}
 
-	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * dt;
-	q1 += qDot2 * dt;
-	q2 += qDot3 * dt;
-	q3 += qDot4 * dt;
+	// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+	if( (ax == 0.0f) && (ay == 0.0f) && (az == 0.0f) ) 
+	{
+		return;
+	}
+	
+	// ----
+	// Main computation
+	// ----		
+	// Auxilirary variables to avoid repeated calculations
+	float half_q1 	= 0.5f * q1;
+	float half_q2 	= 0.5f * q2;
+	float half_q3 	= 0.5f * q3;
+	float half_q4 	= 0.5f * q4;
+	float two_q1 		= 2.0f * q1;
+	float two_q2 		= 2.0f * q2;
+	float two_q3 		= 2.0f * q3;
+	float two_q4 		= 2.0f * q4;
+	float two_bx 		= 2.0f * bx;
+	float two_bz 		= 2.0f * bz;
+	float two_bx_q1 	= 2.0f * bx * q1;
+	float two_bx_q2 	= 2.0f * bx * q2;
+	float two_bx_q3 	= 2.0f * bx * q3;
+	float two_bx_q4 	= 2.0f * bx * q4;
+	float two_bz_q1 	= 2.0f * bz * q1;
+	float two_bz_q2 	= 2.0f * bz * q2;
+	float two_bz_q3 	= 2.0f * bz * q3;
+	float two_bz_q4 	= 2.0f * bz * q4;
+	float q1_q2;
+	float q1_q3 	= q1 * q3;
+	float q1_q4;
+	float q2_q3;
+	float q2_q4 	= q2 * q4;
+	float q3_q4;
+	float two_mx 		= 2.0f * mx;
+	float two_my 		= 2.0f * my;
+	float two_mz 		= 2.0f * mz;
+
+	// Normalise accelerometer measurement
+	recip_norm = maths_fast_inv_sqrt(ax * ax + ay * ay + az * az);
+	ax *= recip_norm;
+	ay *= recip_norm;
+	az *= recip_norm;   
+
+	// Normalise magnetometer measurement
+	recip_norm = maths_fast_inv_sqrt(mx * mx + my * my + mz * mz);
+	mx *= recip_norm;
+	my *= recip_norm;
+	mz *= recip_norm;
+
+	// compute the objective function and Jacobian
+	f1 = -two_q2 * q4 + two_q1 * q3 - ax;
+	f2 = -two_q1 * q2 - two_q3 * q4 - ay;
+	f3 = -1.0f + two_q2 * q2 + two_q3 * q3 - az;
+	f4 = two_bx * (0.5f - q3 * q3 - q4 * q4) + two_bz * (q2_q4 - q1_q3) - mx;
+	f5 = two_bx * (q2 * q3 - q1 * q4) + two_bz * (q1 * q2 + q3 * q4) - my;
+	f6 = two_bx * (q1_q3 + q2_q4) + two_bz * (0.5f - q2 * q2 - q3 * q3) - mz;
+	J_11or24 = -two_q3;					// J_11 negated in matrix multiplication
+	J_12or23 = -2.0f * q4;
+	J_13or22 = -two_q1; 					// J_22 negated in matrix multiplication
+	J_14or21 = -two_q2;
+	J_32 = -2.0f * J_14or21; 				// negated in matrix multiplication
+	J_33 = -2.0f * J_11or24; 				// negated in matrix multiplication
+	J_41 = two_bz_q3; 					// negated in matrix multiplication
+	J_42 = two_bz_q4;
+	J_43 = 2.0f * two_bx_q3 + two_bz_q1; 	// negated in matrix multiplication
+	J_44 = 2.0f * two_bx_q4 - two_bz_q2; 	// negated in matrix multiplication
+	J_51 = two_bx_q4 - two_bz_q2; 			// negated in matrix multiplication
+	J_52 = two_bx_q3 + two_bz_q1;
+	J_53 = two_bx_q2 + two_bz_q4;
+	J_54 = two_bx_q1 - two_bz_q3; 			// negated in matrix multiplication
+	J_61 = two_bx_q3;
+	J_62 = two_bx_q4 - 2.0f * two_bz_q2;
+	J_63 = two_bx_q1 - 2.0f * two_bz_q3;
+	J_64 = two_bx_q2;
+
+	// compute the gradient (matrix multiplication)
+	qhat_dot_1 = J_14or21 * f2 - J_11or24 * f1 - J_41 * f4 - J_51 * f5 + J_61 * f6;
+	qhat_dot_2 = J_12or23 * f1 + J_13or22 * f2 - J_32 * f3 + J_42 * f4 + J_52 * f5 + J_62 * f6;
+	qhat_dot_3 = J_12or23 * f2 - J_33 * f3 - J_13or22 * f1 - J_43 * f4 + J_53 * f5 + J_63 * f6;
+	qhat_dot_4 = J_14or21 * f1 + J_11or24 * f2 - J_44 * f4 - J_54 * f5 + J_64 * f6;
+
+	// normalise the gradient to estimate direction of the gyroscope error
+	norm = maths_fast_sqrt(qhat_dot_1 * qhat_dot_1 + qhat_dot_2 * qhat_dot_2 + qhat_dot_3 * qhat_dot_3 + qhat_dot_4 * qhat_dot_4);
+	qhat_dot_1 = qhat_dot_1 / norm;
+	qhat_dot_2 = qhat_dot_2 / norm;
+	qhat_dot_3 = qhat_dot_3 / norm;
+	qhat_dot_4 = qhat_dot_4 / norm;
+
+	// compute angular estimated direction of the gyroscope error
+	w_err_x = two_q1 * qhat_dot_2 - two_q2 * qhat_dot_1 - two_q3 * qhat_dot_4 + two_q4 * qhat_dot_3;
+	w_err_y = two_q1 * qhat_dot_3 + two_q2 * qhat_dot_4 - two_q3 * qhat_dot_1 - two_q4 * qhat_dot_2;
+	w_err_z = two_q1 * qhat_dot_4 - two_q2 * qhat_dot_3 + two_q3 * qhat_dot_2 - two_q4 * qhat_dot_1;
+
+	// compute and remove the gyroscope baises
+	w_bx += w_err_x * dt * ahrs_madgwick->zeta;
+	w_by += w_err_y * dt * ahrs_madgwick->zeta;
+	w_bz += w_err_z * dt * ahrs_madgwick->zeta;
+	wx -= w_bx;
+	wy -= w_by;
+	wz -= w_bz;
+
+	// compute the quaternion rate measured by gyroscopes
+	q_dot_omega_1 = -half_q2 * wx - half_q3 * wy - half_q4 * wz;
+	q_dot_omega_2 = half_q1 * wx + half_q3 * wz - half_q4 * wy;
+	q_dot_omega_3 = half_q1 * wy - half_q2 * wz + half_q4 * wx;
+	q_dot_omega_4 = half_q1 * wz + half_q2 * wy - half_q3 * wx;
+
+	// compute then integrate the estimated quaternion rate
+	q1 += (q_dot_omega_1 - (ahrs_madgwick->beta * qhat_dot_1)) * dt;
+	q2 += (q_dot_omega_2 - (ahrs_madgwick->beta * qhat_dot_2)) * dt;
+	q3 += (q_dot_omega_3 - (ahrs_madgwick->beta * qhat_dot_3)) * dt;
+	q4 += (q_dot_omega_4 - (ahrs_madgwick->beta * qhat_dot_4)) * dt;
 
 	// Normalise quaternion
-	recipNorm = maths_fast_inv_sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
-	q0 *= recipNorm;
-	q1 *= recipNorm;
-	q2 *= recipNorm;
-	q3 *= recipNorm;
+	recip_norm = maths_fast_inv_sqrt(q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4);
+	q1 *= recip_norm;
+	q2 *= recip_norm;
+	q3 *= recip_norm;
+	q4 *= recip_norm;
 
-	// Store result in ahrs structure
+	// compute flux in the earth frame
+	q1_q2 = q1 * q2; 			// recompute auxilirary variables
+	q1_q3 = q1 * q3; 
+	q1_q4 = q1 * q4; 
+	q3_q4 = q3 * q4; 
+	q2_q3 = q2 * q3; 
+	q2_q4 = q2 * q4; 
+	h_x = two_mx * (0.5f - q3 * q3 - q4 * q4) + two_my * (q2_q3 - q1_q4) + two_mz * (q2_q4 + q1_q3);
+	h_y = two_mx * (q2_q3 + q1_q4) + two_my * (0.5f - q2 * q2 - q4 * q4) + two_mz * (q3_q4 - q1_q2);
+	h_z = two_mx * (q2_q4 - q1_q3) + two_my * (q3_q4 + q1_q2) + two_mz * (0.5f - q2 * q2 - q3 * q3);
+
+	// normalise the flux vector to have only components in the x and z
+	bx = sqrt((h_x * h_x) + (h_y * h_y));
+	bz = h_z;
+
+	// ----
+	// Store result in ahrs and imu structures
+	// ----
 	// Time
 	ahrs_madgwick->ahrs->last_update 	= now;
 	ahrs_madgwick->ahrs->dt 			= dt;
 
 	// Quaternion in NED
-	// q_enu.s 	= q0;
-	// q_enu.v[X] = q1;
-	// q_enu.v[Y] = q2;
-	// q_enu.v[Z] = q3;
-	// ahrs_madgwick->ahrs->qe = quaternions_rotate(q_enu, q_enu2ned);
+	ahrs_madgwick->ahrs->qe.s 		= q1;
+	ahrs_madgwick->ahrs->qe.v[X] 	= q2;
+	ahrs_madgwick->ahrs->qe.v[Y] 	= q3;
+	ahrs_madgwick->ahrs->qe.v[Z] 	= q4;
 
-	q_nwu.s 	= q0;
-	q_nwu.v[X] = q1;
-	q_nwu.v[Y] = q2;
-	q_nwu.v[Z] = q3;
-	ahrs_madgwick->ahrs->qe = quaternions_rotate(q_nwu, q_nwu2ned);
-
+	// Estimate of earth magnetic field orientation
+	ahrs_madgwick->ref_b[X] = bx;
+	ahrs_madgwick->ref_b[Z] = bz;
+	
 	// Angular_speed.
 	ahrs_madgwick->ahrs->angular_speed[X] = ahrs_madgwick->imu->scaled_gyro.data[X];
 	ahrs_madgwick->ahrs->angular_speed[Y] = ahrs_madgwick->imu->scaled_gyro.data[Y];
 	ahrs_madgwick->ahrs->angular_speed[Z] = ahrs_madgwick->imu->scaled_gyro.data[Z];
+
+	// Gyro bias
+	ahrs_madgwick->imu->calib_gyro.bias[X] = w_bx / ahrs_madgwick->imu->calib_gyro.scale_factor[X];
+	ahrs_madgwick->imu->calib_gyro.bias[Y] = w_by / ahrs_madgwick->imu->calib_gyro.scale_factor[Y];
+	ahrs_madgwick->imu->calib_gyro.bias[Z] = w_bz / ahrs_madgwick->imu->calib_gyro.scale_factor[Z];
 
 	// Up vector
 	float up_glob[3] = {0.0f, 0.0f, -1.0f}; 

--- a/sensing/ahrs_madgwick.c
+++ b/sensing/ahrs_madgwick.c
@@ -1,0 +1,280 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2014, MAV'RIC Development Team
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file ahrs_madgwick.h
+ * 
+ * \author MAV'RIC Team
+ * \author SOH Madgwick
+ * \author Julien Lecoeur
+ *   
+ * \brief Implementation of Madgwick's AHRS algorithms.
+ *
+ * See: http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms
+ *
+ * Date			Author          Notes
+ * 29/09/2011	SOH Madgwick    Initial release
+ * 02/10/2011	SOH Madgwick	Optimised for reduced CPU load
+ * 19/02/2012	SOH Madgwick	Magnetometer measurement is normalised
+ * 04/02/2014	Julien Lecoeur	Adapt to MAVRIC
+ *
+ ******************************************************************************/
+
+
+#include "ahrs_madgwick.h"
+#include "maths.h"
+#include "print_util.h"
+#include "constants.h"
+#include "time_keeper.h"
+#include "quaternions.h"
+
+
+bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf_t* config, const imu_t* imu, ahrs_t* ahrs)
+{
+	// Init dependencies
+	ahrs_madgwick->imu 	= imu;
+	ahrs_madgwick->ahrs = ahrs;
+
+	// Init ahrs structure
+	ahrs_madgwick->ahrs->qe.s = 1.0f;
+	ahrs_madgwick->ahrs->qe.v[X] = 0.0f;
+	ahrs_madgwick->ahrs->qe.v[Y] = 0.0f;
+	ahrs_madgwick->ahrs->qe.v[Z] = 0.0f;
+	
+	ahrs_madgwick->ahrs->angular_speed[X] = 0.0f;
+	ahrs_madgwick->ahrs->angular_speed[Y] = 0.0f;
+	ahrs_madgwick->ahrs->angular_speed[Z] = 0.0f;
+	
+	ahrs_madgwick->ahrs->linear_acc[X] = 0.0f;
+	ahrs_madgwick->ahrs->linear_acc[Y] = 0.0f;
+	ahrs_madgwick->ahrs->linear_acc[Z] = 0.0f;
+	
+	ahrs_madgwick->ahrs->north_vec.s    = 0.0f;
+	ahrs_madgwick->ahrs->north_vec.v[X] = 1.0f;
+	ahrs_madgwick->ahrs->north_vec.v[Y] = 0.0f;
+	ahrs_madgwick->ahrs->north_vec.v[Z] = 0.0f;
+	
+	ahrs_madgwick->ahrs->up_vec.s    = 0.0f;
+	ahrs_madgwick->ahrs->up_vec.v[X] = 0.0f;
+	ahrs_madgwick->ahrs->up_vec.v[Y] = 0.0f;
+	ahrs_madgwick->ahrs->up_vec.v[Z] = -1.0f;
+
+	// Init config
+	ahrs_madgwick->beta = config->beta;
+	
+
+
+	// Notify success
+	print_util_dbg_print("[AHRS MADGWICK] Initialised.\r\n");
+
+	return true;
+}
+
+
+void ahrs_madgwick_update(ahrs_madgwick_t* ahrs_madgwick)
+{
+	// Variables required for computation
+	float recipNorm;
+	float s0, s1, s2, s3;
+	float qDot1, qDot2, qDot3, qDot4;
+	float hx, hy;
+	float _2q0mx, _2q0my, _2q0mz, _2q1mx, _2bx, _2bz, _4bx, _4bz, _2q0, _2q1, _2q2, _2q3, _2q0q2, _2q2q3, q0q0, q0q1, q0q2, q0q3, q1q1, q1q2, q1q3, q2q2, q2q3, q3q3;
+	//quat_t q_enu;
+	//quat_t q_enu2ned = {.s=0, .v={0.7071f, 0.7071f, 0.0f}};
+	quat_t q_nwu;
+	quat_t q_nwu2ned = {.s=0, .v={1.0f, 0.0f, 0.0f}};
+
+	// // Get current attitude in ENU
+	// q_enu = quaternions_rotate(ahrs_madgwick->ahrs->qe, quaternions_inverse(q_enu2ned));
+	// float q0 = q_enu.s;
+	// float q1 = q_enu.v[X];
+	// float q2 = q_enu.v[Y];
+	// float q3 = q_enu.v[Z];
+
+	// // Get values from sensors in ENU
+	// float gy = ahrs_madgwick->imu->scaled_gyro.data[X];  
+	// float gx = ahrs_madgwick->imu->scaled_gyro.data[Y];
+	// float gz = -ahrs_madgwick->imu->scaled_gyro.data[Z];
+	// float ay = ahrs_madgwick->imu->scaled_accelero.data[X];
+	// float ax = ahrs_madgwick->imu->scaled_accelero.data[Y];
+	// float az = -ahrs_madgwick->imu->scaled_accelero.data[Z];
+	// float my = ahrs_madgwick->imu->scaled_compass.data[X];
+	// float mx = ahrs_madgwick->imu->scaled_compass.data[Y];
+	// float mz = -ahrs_madgwick->imu->scaled_compass.data[Z];
+
+	// Get current attitude in NWU
+	q_nwu = quaternions_rotate(ahrs_madgwick->ahrs->qe, quaternions_inverse(q_nwu2ned));
+	float q0 = q_nwu.s;
+	float q1 = q_nwu.v[X];
+	float q2 = q_nwu.v[Y];
+	float q3 = q_nwu.v[Z];
+
+	// Get values from sensors in NWU
+	float gx = ahrs_madgwick->imu->scaled_gyro.data[X];  
+	float gy = -ahrs_madgwick->imu->scaled_gyro.data[Y];
+	float gz = -ahrs_madgwick->imu->scaled_gyro.data[Z];
+	float ax = ahrs_madgwick->imu->scaled_accelero.data[X];
+	float ay = -ahrs_madgwick->imu->scaled_accelero.data[Y];
+	float az = -ahrs_madgwick->imu->scaled_accelero.data[Z];
+	// float mx = ahrs_madgwick->imu->scaled_compass.data[X];
+	// float my = -ahrs_madgwick->imu->scaled_compass.data[Y];
+	// float mz = -ahrs_madgwick->imu->scaled_compass.data[Z];
+	float mx = ahrs_madgwick->imu->scaled_compass.data[X];
+	float my = -ahrs_madgwick->imu->scaled_compass.data[Y];
+	float mz = -ahrs_madgwick->imu->scaled_compass.data[Z];
+
+	// Compute time since last update
+	float now 	= time_keeper_get_time(); 
+	float dt 	= now - ahrs_madgwick->ahrs->last_update;
+
+	// Rate of change of quaternion from gyroscope
+	qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+	qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+	qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+	qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+
+	// Use IMU algorithm if magnetometer measurement invalid (avoids NaN in magnetometer normalisation)
+	if( !((mx == 0.0f) && (my == 0.0f) && (mz == 0.0f)) ) 
+	{
+		// Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+		if( !((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)) ) 
+		{
+			// Normalise accelerometer measurement
+			recipNorm = maths_fast_inv_sqrt(ax * ax + ay * ay + az * az);
+			ax *= recipNorm;
+			ay *= recipNorm;
+			az *= recipNorm;   
+
+			// Normalise magnetometer measurement
+			recipNorm = maths_fast_inv_sqrt(mx * mx + my * my + mz * mz);
+			mx *= recipNorm;
+			my *= recipNorm;
+			mz *= recipNorm;
+
+			// Auxiliary variables to avoid repeated arithmetic
+			_2q0mx = 2.0f * q0 * mx;
+			_2q0my = 2.0f * q0 * my;
+			_2q0mz = 2.0f * q0 * mz;
+			_2q1mx = 2.0f * q1 * mx;
+			_2q0 = 2.0f * q0;
+			_2q1 = 2.0f * q1;
+			_2q2 = 2.0f * q2;
+			_2q3 = 2.0f * q3;
+			_2q0q2 = 2.0f * q0 * q2;
+			_2q2q3 = 2.0f * q2 * q3;
+			q0q0 = q0 * q0;
+			q0q1 = q0 * q1;
+			q0q2 = q0 * q2;
+			q0q3 = q0 * q3;
+			q1q1 = q1 * q1;
+			q1q2 = q1 * q2;
+			q1q3 = q1 * q3;
+			q2q2 = q2 * q2;
+			q2q3 = q2 * q3;
+			q3q3 = q3 * q3;
+
+			// Reference direction of Earth's magnetic field
+			hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
+			hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
+			_2bx = sqrt(hx * hx + hy * hy);
+			_2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
+			_4bx = 2.0f * _2bx;
+			_4bz = 2.0f * _2bz;
+
+			// Gradient decent algorithm corrective step
+			s0 = -_2q2 * (2.0f * q1q3 - _2q0q2 - ax) + _2q1 * (2.0f * q0q1 + _2q2q3 - ay) - _2bz * q2 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q3 + _2bz * q1) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q2 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+			s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+			s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+			s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
+			recipNorm = maths_fast_inv_sqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+			s0 *= recipNorm;
+			s1 *= recipNorm;
+			s2 *= recipNorm;
+			s3 *= recipNorm;
+
+			// Apply feedback step
+			qDot1 -= ahrs_madgwick->beta * s0;
+			qDot2 -= ahrs_madgwick->beta * s1;
+			qDot3 -= ahrs_madgwick->beta * s2;
+			qDot4 -= ahrs_madgwick->beta * s3;				
+		}
+	}
+
+	// Integrate rate of change of quaternion to yield quaternion
+	q0 += qDot1 * dt;
+	q1 += qDot2 * dt;
+	q2 += qDot3 * dt;
+	q3 += qDot4 * dt;
+
+	// Normalise quaternion
+	recipNorm = maths_fast_inv_sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+	q0 *= recipNorm;
+	q1 *= recipNorm;
+	q2 *= recipNorm;
+	q3 *= recipNorm;
+
+	// Store result in ahrs structure
+	// Time
+	ahrs_madgwick->ahrs->last_update 	= now;
+	ahrs_madgwick->ahrs->dt 			= dt;
+
+	// Quaternion in NED
+	// q_enu.s 	= q0;
+	// q_enu.v[X] = q1;
+	// q_enu.v[Y] = q2;
+	// q_enu.v[Z] = q3;
+	// ahrs_madgwick->ahrs->qe = quaternions_rotate(q_enu, q_enu2ned);
+
+	q_nwu.s 	= q0;
+	q_nwu.v[X] = q1;
+	q_nwu.v[Y] = q2;
+	q_nwu.v[Z] = q3;
+	ahrs_madgwick->ahrs->qe = quaternions_rotate(q_nwu, q_nwu2ned);
+
+	// Angular_speed.
+	ahrs_madgwick->ahrs->angular_speed[X] = ahrs_madgwick->imu->scaled_gyro.data[X];
+	ahrs_madgwick->ahrs->angular_speed[Y] = ahrs_madgwick->imu->scaled_gyro.data[Y];
+	ahrs_madgwick->ahrs->angular_speed[Z] = ahrs_madgwick->imu->scaled_gyro.data[Z];
+
+	// Up vector
+	float up_glob[3] = {0.0f, 0.0f, -1.0f}; 
+	quaternions_rotate_vector(ahrs_madgwick->ahrs->qe, up_glob, ahrs_madgwick->ahrs->up_vec.v);
+
+	// Update linear acceleration
+	ahrs_madgwick->ahrs->linear_acc[X] = 9.81f * (ahrs_madgwick->imu->scaled_accelero.data[X] - ahrs_madgwick->ahrs->up_vec.v[X]) ;							// TODO: review this line!
+	ahrs_madgwick->ahrs->linear_acc[Y] = 9.81f * (ahrs_madgwick->imu->scaled_accelero.data[Y] - ahrs_madgwick->ahrs->up_vec.v[Y]) ;							// TODO: review this line!
+	ahrs_madgwick->ahrs->linear_acc[Z] = 9.81f * (ahrs_madgwick->imu->scaled_accelero.data[Z] - ahrs_madgwick->ahrs->up_vec.v[Z]) ;							// TODO: review this line!
+
+	// North vector 
+	// TODO: Remove as never used
+	float north_glob[3] = {1.0f, 0.0f, 0.0f}; 
+	quaternions_rotate_vector(ahrs_madgwick->ahrs->qe, north_glob, ahrs_madgwick->ahrs->north_vec.v);
+}

--- a/sensing/ahrs_madgwick.h
+++ b/sensing/ahrs_madgwick.h
@@ -66,7 +66,8 @@ extern "C" {
  */
 typedef struct
 {
-	float 			beta;		// 2 * proportional gain (Kp)
+	float 	beta;		// 2 * proportional gain (Kp)	
+	float 	zeta;			// Gain for gyro drift compensation
 } ahrs_madgwick_conf_t;
 
 
@@ -75,9 +76,11 @@ typedef struct
  */
 typedef struct
 {
-	const imu_t* 	imu;		// Pointer to IMU sensors
-	ahrs_t* 		ahrs;		// Estimated attitude
-	float 			beta;		// 2 * proportional gain (Kp)
+	imu_t* 	imu;			// Pointer to IMU sensors
+	ahrs_t* ahrs;			// Estimated attitude
+	float 	ref_b[3]; 		// Reference direction of magnetic flux in earth frame (x component)
+	float 	beta;			// 2 * proportional gain (Kp)
+	float 	zeta;			// Gain for gyro drift compensation
 } ahrs_madgwick_t;
 
 
@@ -91,7 +94,7 @@ typedef struct
  * 
  * @return 	True if success, false if not
  */
-bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf_t* config, const imu_t* imu, ahrs_t* ahrs);
+bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf_t* config, imu_t* imu, ahrs_t* ahrs);
 
 
 /**

--- a/sensing/ahrs_madgwick.h
+++ b/sensing/ahrs_madgwick.h
@@ -30,69 +30,80 @@
  ******************************************************************************/
 
 /*******************************************************************************
- * \file ahrs.h
+ * \file ahrs_madgwick.h
  * 
  * \author MAV'RIC Team
- * \author Gregoire Heitz
+ * \author SOH Madgwick
+ * \author Julien Lecoeur
  *   
- * \brief This file implements data structure for attitude estimate
+ * \brief Implementation of Madgwick's AHRS algorithms.
+ *
+ * See: http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms
+ *
+ * Date			Author          Notes
+ * 29/09/2011	SOH Madgwick    Initial release
+ * 02/10/2011	SOH Madgwick	Optimised for reduced CPU load
+ * 19/02/2012	SOH Madgwick	Magnetometer measurement is normalised
+ * 04/02/2014	Julien Lecoeur	Adapt to MAVRIC
  *
  ******************************************************************************/
 
 
-#ifndef AHRS_H_
-#define AHRS_H_
+#ifndef AHRS_MADGWICK_H_
+#define AHRS_MADGWICK_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
-#include <stdbool.h>
-#include "quaternions.h"
+
+#include "ahrs.h"
+#include "imu.h"
 
 
 /**
- * \brief Structure containing the Attitude and Heading Reference System
+ * @brief 	Configuration for ahrs _madgwick
  */
 typedef struct
 {
-	quat_t	qe;						///< quaternion defining the Attitude estimation of the platform
-	
-	float	angular_speed[3];		///< Gyro rates
-	float	linear_acc[3];			///< Acceleration WITHOUT gravity
-	
-	float	heading;				///< The heading of the platform
-	quat_t	up_vec;					///< The quaternion of the up vector
-	quat_t	north_vec;				///< The quaternion of the north vector
-	
-	float	last_update;			///< The time of the last IMU update in s
-	float	dt;						///< The time interval between two IMU updates
-} ahrs_t;
+	float 			beta;		// 2 * proportional gain (Kp)
+} ahrs_madgwick_conf_t;
+
 
 /**
- * \brief Configuration for the AHRS structure
+ * @brief 	Structure for the Madgwick attitude estimation filter
  */
-typedef struct  
+typedef struct
 {
-	int32_t x;						///< The mapping for the X axis
-	int32_t y;						///< The mapping for the Y axis
-	int32_t z;						///< The mapping for the Z axis
-}ahrs_config_t;
+	const imu_t* 	imu;		// Pointer to IMU sensors
+	ahrs_t* 		ahrs;		// Estimated attitude
+	float 			beta;		// 2 * proportional gain (Kp)
+} ahrs_madgwick_t;
+
 
 /**
- * \brief   Initialiases the ahrs structure
+ * @brief  	Init function
  * 
- * \param	ahrs 				Pointer to ahrs structure
- * \param	config				Pointer to the config structure
- *
- * \return	True if the init succeed, false otherwise
+ * @param 	ahrs_madgwick 	Pointer to data structure
+ * @param 	config 			Pointer to config structure
+ * @param 	ahrs 			Pointer to AHRS structure
+ * @param 	imu 			Pointer to IMU structure
+ * 
+ * @return 	True if success, false if not
  */
-bool ahrs_init(ahrs_t* ahrs, ahrs_config_t* config);
+bool ahrs_madgwick_init(ahrs_madgwick_t* ahrs_madgwick, const ahrs_madgwick_conf_t* config, const imu_t* imu, ahrs_t* ahrs);
+
+
+/**
+ * @brief 	Main update function
+ * 
+ * @param 	ahrs_madgwick 	Pointer to data structure
+ */
+void ahrs_madgwick_update(ahrs_madgwick_t* ahrs_madgwick);
 
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* AHRS_H_ */
+#endif /* AHRS_MADGWICK_H_ */

--- a/sensing/ahrs_madgwick_default_config.h
+++ b/sensing/ahrs_madgwick_default_config.h
@@ -53,7 +53,8 @@ extern "C" {
 
 static const ahrs_madgwick_conf_t ahrs_madgwick_default_config =
 {
-    .beta = 0.1f,
+    .beta = 0.06f,
+    .zeta = 0.01f,
 };
 
 

--- a/sensing/ahrs_madgwick_default_config.h
+++ b/sensing/ahrs_madgwick_default_config.h
@@ -30,69 +30,35 @@
  ******************************************************************************/
 
 /*******************************************************************************
- * \file ahrs.h
+ * \file ahrs_madgwick_default_config.h
  * 
  * \author MAV'RIC Team
- * \author Gregoire Heitz
+ * \author Julien Lecoeur
  *   
- * \brief This file implements data structure for attitude estimate
+ * \brief Default config for Madgwick's AHRS algorithms.
  *
  ******************************************************************************/
 
 
-#ifndef AHRS_H_
-#define AHRS_H_
+#ifndef AHRS_MADGWICK_DEFAULT_CONFIG_H_
+#define AHRS_MADGWICK_DEFAULT_CONFIG_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
-#include <stdbool.h>
-#include "quaternions.h"
+
+#include "ahrs_madgwick.h"
 
 
-/**
- * \brief Structure containing the Attitude and Heading Reference System
- */
-typedef struct
+static const ahrs_madgwick_conf_t ahrs_madgwick_default_config =
 {
-	quat_t	qe;						///< quaternion defining the Attitude estimation of the platform
-	
-	float	angular_speed[3];		///< Gyro rates
-	float	linear_acc[3];			///< Acceleration WITHOUT gravity
-	
-	float	heading;				///< The heading of the platform
-	quat_t	up_vec;					///< The quaternion of the up vector
-	quat_t	north_vec;				///< The quaternion of the north vector
-	
-	float	last_update;			///< The time of the last IMU update in s
-	float	dt;						///< The time interval between two IMU updates
-} ahrs_t;
-
-/**
- * \brief Configuration for the AHRS structure
- */
-typedef struct  
-{
-	int32_t x;						///< The mapping for the X axis
-	int32_t y;						///< The mapping for the Y axis
-	int32_t z;						///< The mapping for the Z axis
-}ahrs_config_t;
-
-/**
- * \brief   Initialiases the ahrs structure
- * 
- * \param	ahrs 				Pointer to ahrs structure
- * \param	config				Pointer to the config structure
- *
- * \return	True if the init succeed, false otherwise
- */
-bool ahrs_init(ahrs_t* ahrs, ahrs_config_t* config);
+    .beta = 0.1f,
+};
 
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* AHRS_H_ */
+#endif /* AHRS_MADGWICK_DEFAULT_CONFIG_H_ */

--- a/sensing/qfilter.c
+++ b/sensing/qfilter.c
@@ -96,10 +96,10 @@ void qfilter_update(qfilter_t *qf)
 	float kp, kp_mag;
 
 	// Update time
-	uint32_t t = time_keeper_get_time_ticks();
-	float dt = time_keeper_ticks_to_seconds(t - qf->ahrs->last_update);
+	float now 	= time_keeper_get_time();
+	float dt 	= now - qf->ahrs->last_update;
 	qf->ahrs->dt = dt;
-	qf->ahrs->last_update = t;
+	qf->ahrs->last_update = now;
 
 	// up_bf = qe^-1 *(0,0,0,-1) * qe
 	up.s = 0; up.v[0] = UPVECTOR_X; up.v[1] = UPVECTOR_Y; up.v[2] = UPVECTOR_Z;

--- a/util/maths.h
+++ b/util/maths.h
@@ -118,6 +118,35 @@ float static inline maths_calc_smaller_angle(float angle)
 
 
 /**
+ * \brief 			Fast newton iteration for approximate inverse square root
+ * 
+ * \details 		See: http://en.wikipedia.org/wiki/Fast_inverse_square_root
+ * 
+ * \param 	number 	Input value
+ * 
+ * \return 			Output value
+ */
+float static inline maths_fast_inv_sqrt(float number) 
+{
+	union
+	{
+		float	f;
+		int32_t	l;
+	}i;
+	
+	float x, y;
+	const float f = 1.5f;
+
+	x = number * 0.5f;
+	i.f = number;
+	i.l  = 0x5f3759df - ( i.l >> 1 );
+	y = i.f;
+	y = y * ( f - ( x * y * y ) );
+	return y;
+}
+
+
+/**
  * \brief 			Fast newton iteration for approximate square root
  * 
  * \param 	number 	Input value

--- a/util/quaternions.h
+++ b/util/quaternions.h
@@ -178,6 +178,26 @@ quat_t static inline quaternions_inverse(const quat_t q)
 
 
 /**
+ * \brief 			Rotates a quaternion
+ * 
+ * \param 	qi 		Input quaternion
+ * \param 	qe 		Rotation quaternion
+ * 
+ * \return 			Output quaternion (rotated)
+ */
+quat_t static inline quaternions_rotate(const quat_t qi, const quat_t qrot)
+{
+	quat_t qinv, qtmp;
+	
+	qinv = quaternions_inverse(qrot);
+	qtmp = quaternions_multiply(qinv,qi);
+	qtmp = quaternions_multiply(qtmp,qrot);
+
+	return qtmp;
+}
+
+
+/**
  * \brief 			Rotates a vector from global frame to local frame according to an attitude quaternion
  * 
  * \details 		The vector is given in the form of a quaternion with the scalar term equal to 0


### PR DESCRIPTION
I just added a replacement for qfilter. It seems to work fine even though it does not estimate the gyro biases (can be added according to the [original paper](https://imumargalgorithm30042010sohm.googlecode.com/files/An%20efficient%20orientation%20filter%20for%20inertial%20and%20inertialmagnetic%20sensor%20arrays.pdf) ).
Unlike qfilter, it estimates the angle between the horizontal plane and the magnetic field, so that it can use 3 components (qfilter only uses a projection of the magnetic field on the x-y plane).