### PR TITLE
[Project change]: In order not to work with the flashc while flying, a

### DIFF
--- a/communication/mavlink_communication.c
+++ b/communication/mavlink_communication.c
@@ -128,7 +128,7 @@ static void mavlink_communication_toggle_telemetry_stream(scheduler_t* scheduler
 // PUBLIC FUNCTIONS IMPLEMENTATION
 //------------------------------------------------------------------------------
 
-bool mavlink_communication_init(mavlink_communication_t* mavlink_communication, const mavlink_communication_conf_t* config, byte_stream_t* rx_stream, byte_stream_t* tx_stream)
+bool mavlink_communication_init(mavlink_communication_t* mavlink_communication, const mavlink_communication_conf_t* config, byte_stream_t* rx_stream, byte_stream_t* tx_stream, const state_t* state)
 {
 	bool init_success = true;
 	
@@ -150,6 +150,7 @@ bool mavlink_communication_init(mavlink_communication_t* mavlink_communication, 
 	init_success &= onboard_parameters_init(	&mavlink_communication->onboard_parameters, 
 												&config->onboard_parameters_config, 
 												&mavlink_communication->scheduler,
+												state,
 												&mavlink_communication->message_handler,
 												&mavlink_communication->mavlink_stream); 
 

--- a/communication/mavlink_communication.h
+++ b/communication/mavlink_communication.h
@@ -52,7 +52,7 @@ extern "C" {
 #include "mavlink_stream.h"
 #include "mavlink_message_handler.h"
 #include "onboard_parameters.h"
-
+#include "state.h"
 
 /**
  * \brief 		Pointer a module's data structure
@@ -124,12 +124,13 @@ typedef struct
  * 
  * \param 	mavlink_communication 	Pointer to the MAVLink communication structure
  * \param 	config 					Configuration
- * \param 	rx_stream;				Output stream
- * \param 	tx_stream;				Input stream
+ * \param 	rx_stream				Output stream
+ * \param 	tx_stream				Input stream
+ * \param	state					The pointer to the state structure
  *
  * \return	True if the init succeed, false otherwise
  */
-bool mavlink_communication_init(mavlink_communication_t* mavlink_communication, const mavlink_communication_conf_t* config, byte_stream_t* rx_stream, byte_stream_t* tx_stream);
+bool mavlink_communication_init(mavlink_communication_t* mavlink_communication, const mavlink_communication_conf_t* config, byte_stream_t* rx_stream, byte_stream_t* tx_stream, const state_t* state);
 
 
 /**

--- a/communication/onboard_parameters.h
+++ b/communication/onboard_parameters.h
@@ -50,6 +50,7 @@ extern "C" {
 #include "mavlink_stream.h"
 #include "mavlink_message_handler.h"
 #include "scheduler.h"
+#include "state.h"
 
 #include <stdbool.h>
 
@@ -99,6 +100,7 @@ typedef struct
 	const mavlink_stream_t* mavlink_stream;					///< Pointer to mavlink_stream
 	bool debug;												///< Indicates if debug messages should be printed for each param change
 	onboard_parameters_set_t* param_set;					///< Pointer to a set of parameters, needs memory allocation
+	const state_t* state;									///< Pointer to the state structure
 } onboard_parameters_t;											
 
 
@@ -128,11 +130,12 @@ typedef struct
  * \param   	onboard_parameters		Pointer to module structure
  * \param 	config 					Configuration
  * \param 	scheduler 				Pointer to MAVLink scheduler
+ * \param	state					Pointer to the state structure
  * \param 	message_handler 		Pointer to MAVLink message handler
  *
  * \return	True if the init succeed, false otherwise
  */
-bool onboard_parameters_init(onboard_parameters_t* onboard_parameters, const onboard_parameters_conf_t* config, scheduler_t* scheduler, mavlink_message_handler_t* message_handler, const mavlink_stream_t* mavlink_stream);
+bool onboard_parameters_init(onboard_parameters_t* onboard_parameters, const onboard_parameters_conf_t* config, scheduler_t* scheduler, const state_t* state, mavlink_message_handler_t* message_handler, const mavlink_stream_t* mavlink_stream);
 
 
 /**


### PR DESCRIPTION
test is added to check whether the motors are armed or not.
This leads to the following project change:
init_success &= mavlink_communication_init(
&central_data.mavlink_communication,
												&mavlink_config,
																								central_data.telemetry_up_stream,
																																				central_data.telemetry_down_stream,
																																																&central_data.state);