### PR TITLE
Remote callbacks

### DIFF
--- a/communication/remote.c
+++ b/communication/remote.c
@@ -107,25 +107,21 @@ static mode_flag_armed_t get_armed_flag(remote_t* remote)
 
 void trigger_callbacks(remote_t *remote, float *channels_old)
 {
-	int i = 0;
 	remote_callback_item_t *item = remote->callback_list;
 	while(item != NULL)
 	{
 		remote_callback_t* callback = &item->callback;
 		remote_channel_t channel = callback->channel;
-		if(remote->channels[channel] != channels_old[channel])
+		if((remote->channels[channel] > channels_old[channel] && callback->edge != REMOTE_CALLBACK_EDGE_FALLING) ||
+			(remote->channels[channel] < channels_old[channel] && callback->edge != REMOTE_CALLBACK_EDGE_RISING))
 		{
 			if(callback->cb_function != NULL)
 			{
 				(*(callback->cb_function))(callback->cb_struct, remote->channels[channel]);
 			}
 		}
-		i++;
 		item = item->next_item;
 	}
-	print_util_dbg_print("callback count: ");
-	print_util_dbg_print_num(i,10);
-	print_util_dbg_print("\r\n");
 }
 
 
@@ -543,13 +539,14 @@ void remote_get_velocity_command(const remote_t* remote, velocity_command_t * co
  * \brief	Register a callback that is triggered when the value of a channel changes
  *
  * \param	remote				The pointer to the remote structure
- * \param	callback_function	Pointer to the callback function
+ * \param	callback_function	Pointer to the callback function; function should be of the form void foo(callback_struct, float value);
  * \param	callback_struct		Struct that is passed to the callback function
  * \param	remote_channel		channel which triggers the callback
+ * \param	edge 				Edge of the signal to be detected: REMOTE_CALLBACK_EDGE_FALLING, REMOTE_CALLBACK_EDGE_RISING, REMOTE_CALLBACK_EDGE_BOTHREMOTE_CALLBACK_EDGE_RAISING
  *
  * \return 	True if callback could be registered
  */
-bool remote_callback_register(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel)
+bool remote_callback_register(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel, remote_callback_edge_t edge)
 {
 	/* malloc space for remote_callback_item_t */
 	remote_callback_item_t* item = malloc(sizeof(remote_callback_item_t));
@@ -565,6 +562,7 @@ bool remote_callback_register(remote_t *remote, void (*callback_function)(void *
 	callback->cb_function = callback_function;
 	callback->cb_struct = callback_struct;
 	callback->channel = channel;
+	callback->edge = edge;
 
 	/* insert the callback_item at the head of the callback list */
 	remote_callback_item_t* first_element = remote->callback_list;
@@ -582,10 +580,11 @@ bool remote_callback_register(remote_t *remote, void (*callback_function)(void *
  * \param	callback_function	Pointer to the callback function
  * \param	callback_struct		Struct that is passed to the callback function
  * \param	remote_channel		channel which triggers the callback
+ * \param	edge 				Edge of the signal to be detected: REMOTE_CALLBACK_EDGE_FALLING, REMOTE_CALLBACK_EDGE_RISING, REMOTE_CALLBACK_EDGE_BOTHREMOTE_CALLBACK_EDGE_RAISING
  *
  * \return 	True if callback could be unregistered;
  */
-bool remote_callback_unregister(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel)
+bool remote_callback_unregister(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel, remote_callback_edge_t edge)
 {
 	/* find the item to be deleted */
 	remote_callback_item_t *previous_item = NULL;
@@ -594,7 +593,8 @@ bool remote_callback_unregister(remote_t *remote, void (*callback_function)(void
 		remote_callback_t *callback = &item->callback;
 		if(callback->cb_function == callback_function &&
 			callback->cb_struct == callback_struct &&
-			callback->channel == channel)
+			callback->channel == channel &&
+			callback->edge == edge)
 		{
 			/* remove item from the list */
 			if (previous_item != NULL)

--- a/communication/remote.h
+++ b/communication/remote.h
@@ -104,6 +104,18 @@ typedef enum
 	REMOTE_SPEKTRUM = 1,
 } remote_type_t;
 
+
+/**
+ * \brief The type of the remote
+ */
+typedef enum
+{
+	REMOTE_CALLBACK_EDGE_FALLING = -1,
+	REMOTE_CALLBACK_EDGE_BOTH	= 0,
+	REMOTE_CALLBACK_EDGE_RISING	= 1
+} remote_callback_edge_t;
+
+
 /**
  * \brief The configuration structure of the remote mode
  */
@@ -151,6 +163,7 @@ typedef struct
 	void (*cb_function)(void *, float);						///< Pointer to the callback function; function should be of the form void foo(callback_struct, float value); function is called as value changes
 	void *cb_struct;										///< Struct that is passed to the callback function;
 	remote_channel_t channel;								///< channel which triggers the callback
+	remote_callback_edge_t edge;							///< Edge of the signal to be detected: falling, both, rising
  } remote_callback_t;
 
  /**
@@ -366,10 +379,11 @@ void remote_get_velocity_command(const remote_t* remote, velocity_command_t * co
  * \param	callback_function	Pointer to the callback function; function should be of the form void foo(callback_struct, float value);
  * \param	callback_struct		Struct that is passed to the callback function
  * \param	remote_channel		channel which triggers the callback
+ * \param	edge 				Edge of the signal to be detected: REMOTE_CALLBACK_EDGE_FALLING, REMOTE_CALLBACK_EDGE_RISING, REMOTE_CALLBACK_EDGE_BOTHREMOTE_CALLBACK_EDGE_RAISING
  *
  * \return 	True if callback could be registered
  */
-bool remote_callback_register(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel);
+bool remote_callback_register(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel, remote_callback_edge_t edge);
 
 
 /**
@@ -379,10 +393,11 @@ bool remote_callback_register(remote_t *remote, void (*callback_function)(void *
  * \param	callback_function	Pointer to the callback function
  * \param	callback_struct		Struct that is passed to the callback function
  * \param	remote_channel		channel which triggers the callback
+ * \param	edge 				Edge of the signal to be detected: REMOTE_CALLBACK_EDGE_FALLING, REMOTE_CALLBACK_EDGE_RISING, REMOTE_CALLBACK_EDGE_BOTHREMOTE_CALLBACK_EDGE_RAISING
  *
  * \return 	True if callback could be unregistered;
  */
-bool remote_callback_unregister(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel);
+bool remote_callback_unregister(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel, remote_callback_edge_t edge);
 
 
 #ifdef __cplusplus

--- a/communication/remote.h
+++ b/communication/remote.h
@@ -54,7 +54,6 @@
 #include "control_command.h"
 
 #define REMOTE_CHANNEL_COUNT 14
-#define REMOTE_CALLBACK_COUNT_MAX 3
 
 /**
  * \brief The signal's quality
@@ -154,6 +153,18 @@ typedef struct
 	remote_channel_t channel;								///< channel which triggers the callback
  } remote_callback_t;
 
+ /**
+ * \brief List element containing a remote_callback_t
+ */
+ typedef struct remote_callback_item_t remote_callback_item_t;
+ struct remote_callback_item_t
+ {
+	remote_callback_t callback;						///< Callback of the list element
+	remote_callback_item_t *next_item;				///< Points to the next element
+ };
+
+
+
 /**
  * \brief The configuration structure of the remote
  */
@@ -177,8 +188,7 @@ typedef struct
 	signal_quality_t signal_quality;						///< The quality of signal
 	remote_type_t type;										///< The type of remote
 	remote_mode_t mode;										///< The remote mode structure
-	remote_callback_t callback_list[REMOTE_CALLBACK_COUNT_MAX]; ///< List containing all remote_callbacks
-	int callback_count;								///< Number of registered callbacks
+	remote_callback_item_t *callback_list;					///< List containing all remote_callbacks (pointer to first list element)
 } remote_t;
 
 /**
@@ -357,7 +367,7 @@ void remote_get_velocity_command(const remote_t* remote, velocity_command_t * co
  * \param	callback_struct		Struct that is passed to the callback function
  * \param	remote_channel		channel which triggers the callback
  *
- * \return 	True if callback could be registered; false if an error occurred (typically already all callbacks used -> increase REMOTE_CALLBACK_COUNT_MAX)
+ * \return 	True if callback could be registered
  */
 bool remote_callback_register(remote_t *remote, void (*callback_function)(void *, float), void *callback_struct, remote_channel_t channel);
 


### PR DESCRIPTION
This fixes issue #103:
Allows to register callbacks on remote switches outside of the library

Usage: 
remote_callback_register(remote, my_cb_function, my_structure, remote_channel);
As the value of remote_channel changes, the function my_cb_function(my_structure, new_value); is called.