### PR TITLE
add epuck communication module

### DIFF
--- a/communication/epuck_communication.c
+++ b/communication/epuck_communication.c
@@ -51,12 +51,27 @@ void epuck_communication_init(epuck_communication_t* epuck_communication, const 
 	uart_int_set_usart_conf(UID, &usart_conf_epuck);
 	
 	uart_int_init(UID);
-	buffer_make_buffered_stream(&(epuck_communication->epuck_buffer), (epuck_communication->mavlink_stream.rx));
-	uart_int_register_read_stream(uart_int_get_uart_handle(UID), (epuck_communication->mavlink_stream.rx));
-	uart_int_register_write_stream(uart_int_get_uart_handle(UID), (epuck_communication->mavlink_stream.tx));
+	buffer_make_buffered_stream(&(epuck_communication->uart_buffer_in), &(epuck_communication->uart_stream_in));
+	buffer_make_buffered_stream(&(epuck_communication->uart_buffer_out), &(epuck_communication->uart_stream_out));
+	uart_int_register_read_stream(uart_int_get_uart_handle(UID), &(epuck_communication->uart_stream_in));
+	uart_int_register_write_stream(uart_int_get_uart_handle(UID), &(epuck_communication->uart_stream_out));
 	
 	//init dependencies
 	epuck_communication->remote = remote;
+	
+	//init stream
+	// Init MAVLink stream
+	// TODO: find a way to use mavlink_communication_default_config.mavlink_stream_config instead
+	mavlink_stream_conf_t mavlink_stream_conf =
+	{
+		.sysid       = 1,
+		.compid      = 50,
+		.use_dma     = false
+	};
+	mavlink_stream_init(	&(epuck_communication->mavlink_stream),
+							&mavlink_stream_conf,
+							&(epuck_communication->uart_stream_in),
+							&(epuck_communication->uart_stream_out));
 }
 
 

--- a/communication/epuck_communication.c
+++ b/communication/epuck_communication.c
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2014, MAV'RIC Development Team
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file epuck_communication.c
+ * 
+ * \author MAV'RIC Team
+ * \author Gregoire Heitz
+ *   
+ * \brief	This file configures the epuck UART communication
+ *			and send remote scaled messages to the epuck to be used to drive its wheels
+ *
+ ******************************************************************************/
+
+
+#include "epuck_communication.h"
+#include "time_keeper.h"
+
+
+void epuck_communication_init(epuck_communication_t* epuck_communication, const remote_t* remote, int32_t UID, usart_config_t usart_conf_epuck)
+{
+	//uart init
+	uart_int_set_usart_conf(UID, &usart_conf_epuck);
+	
+	uart_int_init(UID);
+	buffer_make_buffered_stream(&(epuck_communication->epuck_buffer), (epuck_communication->mavlink_stream.rx));
+	uart_int_register_read_stream(uart_int_get_uart_handle(UID), (epuck_communication->mavlink_stream.rx));
+	uart_int_register_write_stream(uart_int_get_uart_handle(UID), (epuck_communication->mavlink_stream.tx));
+	
+	//init dependencies
+	epuck_communication->remote = remote;
+}
+
+
+task_return_t epuck_communication_update(epuck_communication_t* epuck_communication)
+{
+	mavlink_message_t msg;
+	
+	mavlink_msg_rc_channels_scaled_pack(	epuck_communication->mavlink_stream.sysid,
+											epuck_communication->mavlink_stream.compid,
+											&msg,
+											time_keeper_get_millis(),
+											0,
+											epuck_communication->remote->channels[0] * 10000.0f,
+											epuck_communication->remote->channels[1] * 10000.0f,
+											epuck_communication->remote->channels[2] * 10000.0f,
+											epuck_communication->remote->channels[3] * 10000.0f,
+											epuck_communication->remote->channels[4] * 10000.0f,
+											epuck_communication->remote->channels[5] * 10000.0f,
+											epuck_communication->remote->channels[6] * 10000.0f,
+											epuck_communication->remote->channels[7] * 10000.0f,
+											epuck_communication->remote->mode.current_desired_mode.byte );
+											// epuck_communication->remote->signal_quality	);
+	
+	mavlink_stream_send(&(epuck_communication->mavlink_stream), &msg);
+
+	return TASK_RUN_SUCCESS;
+}

--- a/communication/epuck_communication.h
+++ b/communication/epuck_communication.h
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2014, MAV'RIC Development Team
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file epuck_communication.h
+ * 
+ * \author MAV'RIC Team
+ * \author Gregoire Heitz
+ *   
+ * \brief	This file configures the epuck UART communication
+ *			and send remote scaled messages to the epuck to be used to drive its wheels
+ *
+ ******************************************************************************/
+#ifndef EPUCK_COMMUNICATION_H_
+#define EPUCK_COMMUNICATION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mavlink_stream.h"
+#include "buffer.h"
+#include "remote.h"
+
+/**
+ * \brief Defines the state machine structure
+ */
+typedef struct 
+{
+	mavlink_stream_t 	mavlink_stream;		///< Mavlink interface using streams
+	buffer_t			epuck_buffer;		///< Buffer to store epuck stuff
+	const remote_t*		remote;				///< Pointer to the remote structure
+} epuck_communication_t;
+
+/**
+ * \brief						Initialize the epuck comm module
+ *
+ * \param UID					UART ID from UART0 to UART4
+ * \param usart_conf_console
+ */
+void epuck_communication_init(epuck_communication_t* epuck_communication, const remote_t* remote, int32_t UID, usart_config_t usart_conf_epuck);
+
+/**
+ * \brief   Updates the Epuck communication
+ *
+ * \param	epuck_communication			Pointer to the epuck_communication structure
+ * 
+ * \return Returns the result of the task
+ */
+task_return_t epuck_communication_update(epuck_communication_t* epuck_communication);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //EPUCK_COMMUNICATION_H_

--- a/communication/epuck_communication.h
+++ b/communication/epuck_communication.h
@@ -56,15 +56,21 @@ extern "C" {
 typedef struct 
 {
 	mavlink_stream_t 	mavlink_stream;		///< Mavlink interface using streams
-	buffer_t			epuck_buffer;		///< Buffer to store epuck stuff
+	byte_stream_t		uart_stream_in;		///< stream from Epuck
+	byte_stream_t		uart_stream_out;	///< stream towards Epuck
+	buffer_t			uart_buffer_in;		///< buffer for messages received from Epuck
+	buffer_t			uart_buffer_out;	///< buffer for messages to sent towards Epuck
+	
 	const remote_t*		remote;				///< Pointer to the remote structure
 } epuck_communication_t;
 
 /**
  * \brief						Initialize the epuck comm module
  *
+ * \param epuck_communication	Pointer to the epuck communication structure
+ * \param remote				Pointer to the remote structure
  * \param UID					UART ID from UART0 to UART4
- * \param usart_conf_console
+ * \param usart_conf_epuck		Uart configuration to talk to the epuck
  */
 void epuck_communication_init(epuck_communication_t* epuck_communication, const remote_t* remote, int32_t UID, usart_config_t usart_conf_epuck);
 


### PR DESCRIPTION
To be used to communicate with the epuck.
It sends mavlink remote_scaled messages by uart, with a baudrate of 115200.
You can find the epuck code that reads those message and drive the wheel motors according to remote pitch and roll command, in Utility/Epuck_interface folder.

To test it, one should go in MAVRIC and adapt src files:

board_support.c
add this include
```
#include "epuck_communication.h"
```
and update this accordingly
```
// Init UART 3 for GPS communication
//gps_ublox_init(&(central_data->gps), UART3, usart_default_config_gps);
//or
// Init UART 3 for Epuck communication
epuck_communication_init(&(central_data->epuck_communication), &(central_data->remote), UART3, usart_default_config_gps);
```

then in central_data.h, 
add this include
```
#include "epuck_communication.h"
```
and add a epuck_communication object
```
epuck_communication_t epuck_communication;					///< The Epuck communication structure
```

then in tasks.c, remove the gps task, if you used gps port as proposed above and add the epuck_communication_update one instead
add this include
```
#include "epuck_communication.h"
```
and
```
//init_success &= scheduler_add_task(scheduler, 100000, 	RUN_REGULAR, PERIODIC_ABSOLUTE, PRIORITY_HIGH   , &tasks_run_gps_update                                             , 0 													, 3);
	init_success &= scheduler_add_task(scheduler, 4000, 	RUN_REGULAR, PERIODIC_ABSOLUTE, PRIORITY_NORMAL , (task_function_t)&epuck_communication_update						, (task_argument_t)&central_data->epuck_communication	, 3);
```