### PR TITLE
Mavripuck

### DIFF
--- a/communication/mavlink_communication.c
+++ b/communication/mavlink_communication.c
@@ -137,7 +137,7 @@ bool mavlink_communication_init(mavlink_communication_t* mavlink_communication, 
 									&config->scheduler_config);
 
 	// Init MAVLink stream
-	mavlink_stream_init(	&mavlink_communication->mavlink_stream, 
+	init_success &= mavlink_stream_init(	&mavlink_communication->mavlink_stream, 
 							&config->mavlink_stream_config,
 							rx_stream,
 							tx_stream	);

--- a/communication/mavlink_communication_default_config.h
+++ b/communication/mavlink_communication_default_config.h
@@ -60,9 +60,9 @@ mavlink_communication_conf_t mavlink_communication_default_config =
 	},
 	.mavlink_stream_config =
 	{
-		.sysid       = 1,
-		.compid      = 50,
-		.use_dma     = false
+		.sysid   = 1,
+		.compid  = 50,
+		.debug   = true,
 	},
 	.message_handler_config =
 	{

--- a/communication/mavlink_stream.c
+++ b/communication/mavlink_stream.c
@@ -84,6 +84,11 @@ bool mavlink_stream_init(	mavlink_stream_t* mavlink_stream,
 		success = false;
 	}
 
+	if( success == true )
+	{
+		print_util_dbg_print("[MAVLINK STREAM] Initialized\r\n");	
+	}
+
 	return success;
 }
 

--- a/communication/mavlink_stream.c
+++ b/communication/mavlink_stream.c
@@ -42,10 +42,7 @@
 
 #include "mavlink_stream.h"
 #include "buffer.h"
-#include "onboard_parameters.h"
 #include "print_util.h"
-
-#include "mavlink_message_handler.h"
 
 
 //------------------------------------------------------------------------------

--- a/communication/mavlink_stream.c
+++ b/communication/mavlink_stream.c
@@ -52,11 +52,13 @@
 // PUBLIC FUNCTIONS IMPLEMENTATION
 //------------------------------------------------------------------------------
 
-void mavlink_stream_init(	mavlink_stream_t* mavlink_stream, 
+bool mavlink_stream_init(	mavlink_stream_t* mavlink_stream, 
 				const mavlink_stream_conf_t* config, 
 				byte_stream_t* rx_stream, 
 				byte_stream_t* tx_stream)
 {
+	bool success = false;
+
 	// Init static variable storing number of mavlink stream instances
 	static uint8_t nb_mavlink_stream_instances = 0;
 	if( nb_mavlink_stream_instances < MAVLINK_COMM_NUM_BUFFERS )
@@ -70,6 +72,8 @@ void mavlink_stream_init(	mavlink_stream_t* mavlink_stream,
 		mavlink_stream->compid          = config->compid;
 		mavlink_stream->debug          = config->debug;
 		mavlink_stream->msg_available   = false;
+
+		success = true;
 	}
 	else
 	{
@@ -79,7 +83,11 @@ void mavlink_stream_init(	mavlink_stream_t* mavlink_stream,
 			print_util_dbg_print("[MAVLINK STREAM] Error: Too many instances !");
 			print_util_dbg_print("[MAVLINK STREAM] Try to increase MAVLINK_COMM_NUM_BUFFERS");	
 		}
+
+		success = false;
 	}
+
+	return success;
 }
 
 

--- a/communication/mavlink_stream.h
+++ b/communication/mavlink_stream.h
@@ -92,7 +92,7 @@ typedef struct
 	mavlink_received_t rec;		///< Last received message
 	bool msg_available;		///< Indicates if a new message is available and not handled yet
 	uint8_t mavlink_channel; 	///< Channel number used internally by mavlink to retrieve incomplete incoming message
-	bool debug;
+	bool debug;			///< Debug flag
 } mavlink_stream_t;
 
 

--- a/communication/mavlink_stream.h
+++ b/communication/mavlink_stream.h
@@ -90,7 +90,7 @@ typedef struct
 	byte_stream_t* rx;		///< Input stream
 	uint32_t sysid;			///< System ID
 	uint32_t compid;		///< System Component ID
-	mavlink_received_t rec;	///< Last received message
+	mavlink_received_t rec;		///< Last received message
 	bool msg_available;		///< Indicates if a new message is available and not handled yet
 	bool use_dma;			///< Indicates whether tx transfer should use dma
 } mavlink_stream_t;

--- a/communication/mavlink_stream.h
+++ b/communication/mavlink_stream.h
@@ -114,8 +114,10 @@ typedef struct
  * \param 	config				Configuration
  * \param 	rx_stream;			Output stream
  * \param 	tx_stream;			Input stream
+ * 
+ * \return 	Success
  */
-void mavlink_stream_init(mavlink_stream_t* mavlink_stream, const mavlink_stream_conf_t* config, byte_stream_t* rx_stream, byte_stream_t* tx_stream);
+bool mavlink_stream_init(mavlink_stream_t* mavlink_stream, const mavlink_stream_conf_t* config, byte_stream_t* rx_stream, byte_stream_t* tx_stream);
 
 
 /**

--- a/communication/mavlink_stream.h
+++ b/communication/mavlink_stream.h
@@ -64,7 +64,6 @@ extern "C" {
 	#define NATIVE_BIG_ENDIAN
 #endif
 
-
 #include "libs/mavlink/include/mavric/mavlink.h"
 
 
@@ -92,7 +91,8 @@ typedef struct
 	uint32_t compid;		///< System Component ID
 	mavlink_received_t rec;		///< Last received message
 	bool msg_available;		///< Indicates if a new message is available and not handled yet
-	bool use_dma;			///< Indicates whether tx transfer should use dma
+	uint8_t mavlink_channel; 	///< Channel number used internally by mavlink to retrieve incomplete incoming message
+	bool debug;
 } mavlink_stream_t;
 
 
@@ -103,7 +103,7 @@ typedef struct
 {
 	uint32_t sysid;					///< System ID
 	uint32_t compid;				///< System Component ID
-	bool use_dma;
+	bool  	 debug; 				///< Debug flag
 } mavlink_stream_conf_t;
 
 

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -42,6 +42,21 @@
 #include "flow.h"
 #include "time_keeper.h"
 
+
+//------------------------------------------------------------------------------
+// PRIVATE FUNCTIONS IMPLEMENTATION
+//------------------------------------------------------------------------------
+
+static inline int16_t endian_rev16(int16_t data)
+{
+	return ((data >> 8) & 0x00ff) | ((data & 0x00ff) << 8);
+};
+
+
+//------------------------------------------------------------------------------
+// PUBLIC FUNCTIONS IMPLEMENTATION
+//------------------------------------------------------------------------------
+
 void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
 {
 	// Init members
@@ -70,10 +85,6 @@ void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
 				&(flow->uart_stream_out));
 }
 
-static inline int16_t endian_rev16(int16_t data)
-{
-	return ((data >> 8) & 0x00ff) | ((data & 0x00ff) << 8);
-};
 
 void flow_update(flow_t* flow)
 {

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -62,7 +62,7 @@ void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
 	{
 		.sysid       = 1,
 		.compid      = 50,
-		.use_dma     = false
+		.debug       = true,
 	};
 	mavlink_stream_init(	&(flow->mavlink_stream),
 				&mavlink_stream_conf,
@@ -165,12 +165,12 @@ void flow_update(flow_t* flow)
 								flow->of.data[i + data_msg.seqnr * MAVLINK_MSG_ENCAPSULATED_DATA_FIELD_DATA_LEN] = data_msg.data[i];
 							}
 						}
-						else if( data_msg.seqnr < flow->n_packets )
+						else if( data_msg.seqnr == (flow->n_packets-1) )
 						{
 							// last packet
 							for ( int i = 0; i < flow->size_data % MAVLINK_MSG_ENCAPSULATED_DATA_FIELD_DATA_LEN; ++i)
 							{
-								// flow->of.data[i + data_msg.seqnr * MAVLINK_MSG_ENCAPSULATED_DATA_FIELD_DATA_LEN] = data_msg.data[i];
+								flow->of.data[i + data_msg.seqnr * MAVLINK_MSG_ENCAPSULATED_DATA_FIELD_DATA_LEN] = data_msg.data[i];
 							}
 
 							// swap bytes

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -41,7 +41,7 @@
 
 #include "flow.h"
 #include "time_keeper.h"
-
+#include "print_util.h"
 
 //------------------------------------------------------------------------------
 // PRIVATE FUNCTIONS IMPLEMENTATION
@@ -88,6 +88,12 @@ bool flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
 					&mavlink_stream_conf,
 					&(flow->uart_stream_in),
 					&(flow->uart_stream_out));
+
+
+	if( success == true )
+	{
+		print_util_dbg_print("[Flow] Initialized\r\n");	
+	}
 
 	return success;
 }

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2015, MAV'RIC Development Team
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file flow.c
+ * 
+ * \author MAV'RIC Team
+ * \author Julien Lecoeur
+ *
+ * \brief Driver for optic flow sensors
+ *
+ ******************************************************************************/
+
+#include "flow.h"
+
+
+void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
+{
+	// Init uart and buffers
+	uart_int_set_usart_conf(UID, &usart_conf);
+	uart_int_init(UID);
+	buffer_make_buffered_stream(&(flow->uart_buffer_in), &(flow->uart_stream_in));
+	buffer_make_buffered_stream(&(flow->uart_buffer_out), &(flow->uart_stream_out));
+	uart_int_register_read_stream(uart_int_get_uart_handle(UID), &(flow->uart_stream_in));
+	uart_int_register_write_stream(uart_int_get_uart_handle(UID), &(flow->uart_stream_out));
+	
+	// Init MAVLink stream
+	mavlink_stream_conf_t mavlink_stream_conf =
+	{
+		.sysid       = 1,
+		.compid      = 50,
+		.use_dma     = false
+	};
+	mavlink_stream_init(	&(flow->mavlink_stream),
+				&mavlink_stream_conf,
+				&(flow->uart_stream_in),
+				&(flow->uart_stream_out));
+}
+
+void flow_update(flow_t* flow)
+{
+	// Receive incoming bytes
+	mavlink_stream_receive(&flow->mavlink_stream);
+
+	// Check if a new message is here
+	if( flow->mavlink_stream.msg_available == true )
+	{
+		// Get pointer to new message
+		mavlink_message_t* msg = &flow->mavlink_stream.rec.msg; 
+		
+		// Indicate that the message was handled
+		flow->mavlink_stream.msg_available = false;
+		
+		mavlink_optical_flow_t optical_flow_msg;
+
+		switch( msg->msgid )
+		{
+			case MAVLINK_MSG_ID_OPTICAL_FLOW:
+				mavlink_msg_optical_flow_decode(msg, &optical_flow_msg);
+				
+				flow->tmp_flow_x 	= optical_flow_msg.flow_x;
+				flow->tmp_flow_x 	= optical_flow_msg.flow_y;
+				flow->tmp_flow_comp_m_x = optical_flow_msg.flow_comp_m_x;
+				flow->tmp_flow_comp_m_y = optical_flow_msg.flow_comp_m_y;
+			break;
+		}
+	}
+}	

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -92,7 +92,7 @@ bool flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
 
 	if( success == true )
 	{
-		print_util_dbg_print("[Flow] Initialized\r\n");	
+		print_util_dbg_print("[FLOW] Initialized\r\n");	
 	}
 
 	return success;

--- a/drivers/flow.h
+++ b/drivers/flow.h
@@ -60,8 +60,15 @@ typedef union
 		int16_t x[125];
 		int16_t y[125];
 	};
-	uint8_t raw_data[500];
+	uint8_t data[500];
 } flow_data_t;
+
+typedef enum
+{
+	FLOW_NO_HANDSHAKE       = 0,
+	FLOW_HANDSHAKE_DATA     = 1,
+	FLOW_HANDSHAKE_METADATA = 2,
+} flow_handshake_state_t;
 
 typedef struct
 {
@@ -71,9 +78,15 @@ typedef struct
 	buffer_t		uart_buffer_in;		///< buffer for messages received from Epuck
 	buffer_t		uart_buffer_out;	///< buffer for messages to sent towards Epuck
 
-	flow_data_t data;
+	uint8_t 	of_count;
+	flow_data_t 	of;
+	flow_data_t 	of_loc;
 
-	uint32_t last_update;
+	flow_handshake_state_t  handshake_state; 
+	uint16_t 		n_packets;
+	uint32_t 		size_data; 
+
+	uint32_t last_update_us;
 
 	float tmp_flow_x;
 	float tmp_flow_y;

--- a/drivers/flow.h
+++ b/drivers/flow.h
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2015, MAV'RIC Development Team
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file flow.h
+ * 
+ * \author MAV'RIC Team
+ * \author Julien Lecoeur
+ *
+ * \brief Driver for optic flow sensors
+ *
+ ******************************************************************************/
+
+#ifndef FLOW_H_
+#define FLOW_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "mavlink_stream.h"
+#include "buffer.h"
+#include "uart_int.h"
+
+#include <stdint.h>
+
+
+typedef union
+{
+	struct 
+	{
+		int16_t x[125];
+		int16_t y[125];
+	};
+	uint8_t raw_data[500];
+} flow_data_t;
+
+typedef struct
+{
+	mavlink_stream_t 	mavlink_stream;		///< Mavlink interface using streams
+	byte_stream_t		uart_stream_in;		///< stream from Epuck
+	byte_stream_t		uart_stream_out;	///< stream towards Epuck
+	buffer_t		uart_buffer_in;		///< buffer for messages received from Epuck
+	buffer_t		uart_buffer_out;	///< buffer for messages to sent towards Epuck
+
+	flow_data_t data;
+
+	uint32_t last_update;
+
+	float tmp_flow_x;
+	float tmp_flow_y;
+	float tmp_flow_comp_m_x;
+	float tmp_flow_comp_m_y;
+} flow_t;
+
+
+void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf);
+
+void flow_update(flow_t* flow);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLOW_H_ */

--- a/drivers/flow.h
+++ b/drivers/flow.h
@@ -72,9 +72,9 @@ typedef union
  */
 typedef enum
 {
-	FLOW_NO_HANDSHAKE       = 0,
-	FLOW_HANDSHAKE_DATA     = 1,
-	FLOW_HANDSHAKE_METADATA = 2,
+	FLOW_NO_HANDSHAKE       = 0,	///< No handshake received
+	FLOW_HANDSHAKE_DATA     = 1, 	///< Normal data will be received
+	FLOW_HANDSHAKE_METADATA = 2, 	///< Metadata will be received
 } flow_handshake_state_t;
 
 
@@ -112,16 +112,20 @@ typedef struct
  * \param flow 		Pointer to flow structure
  * \param UID  		Uart ID
  * \param usart_conf 	Uart config
+ * 
+ * \return 		Success
  */
-void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf);
+bool flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf);
 
 
 /**
  * \brief Update function
  * 
  * \param flow 		Pointer to flow structure
+ * 
+ * \return 		Success
  */
-void flow_update(flow_t* flow);
+bool flow_update(flow_t* flow);
 
 
 #ifdef __cplusplus

--- a/drivers/flow.h
+++ b/drivers/flow.h
@@ -53,16 +53,23 @@ extern "C" {
 #include <stdint.h>
 
 
+/**
+ * \brief 	Array of 2-D optic flow vectors
+ */
 typedef union
 {
 	struct 
 	{
-		int16_t x[125];
-		int16_t y[125];
+		int16_t x[125];		///< Horizontal component
+		int16_t y[125];		///< Vertical component
 	};
-	uint8_t data[500];
+	uint8_t data[500];		///< Raw access to data
 } flow_data_t;
 
+
+/**
+ * \brief	State of encapsulated data transfer
+ */
 typedef enum
 {
 	FLOW_NO_HANDSHAKE       = 0,
@@ -70,6 +77,10 @@ typedef enum
 	FLOW_HANDSHAKE_METADATA = 2,
 } flow_handshake_state_t;
 
+
+/**
+ * \brief 	Data structure for Flow
+ */
 typedef struct
 {
 	mavlink_stream_t 	mavlink_stream;		///< Mavlink interface using streams
@@ -78,26 +89,40 @@ typedef struct
 	buffer_t		uart_buffer_in;		///< buffer for messages received from Epuck
 	buffer_t		uart_buffer_out;	///< buffer for messages to sent towards Epuck
 
-	uint8_t 	of_count;
-	flow_data_t 	of;
-	flow_data_t 	of_loc;
+	uint8_t 	of_count;			///< Number of optic flow vectors
+	flow_data_t 	of;				///< Optic flow vectors
+	flow_data_t 	of_loc;				///< Location of optic flow vectors
 
-	flow_handshake_state_t  handshake_state; 
-	uint16_t 		n_packets;
-	uint32_t 		size_data; 
+	flow_handshake_state_t  handshake_state; 	///< Indicates the current reception state for encapsulated data
+	uint16_t 		n_packets;		///< Number of encapsulated data packets expected
+	uint32_t 		size_data; 		///< Total size of data to receive (in bytes)
 
-	uint32_t last_update_us;
+	uint32_t last_update_us;			///< Last update time in microseconds
 
-	float tmp_flow_x;
-	float tmp_flow_y;
-	float tmp_flow_comp_m_x;
-	float tmp_flow_comp_m_y;
+	float tmp_flow_x;		///< Tmp debug data
+	float tmp_flow_y;		///< Tmp debug data
+	float tmp_flow_comp_m_x;	///< Tmp debug data
+	float tmp_flow_comp_m_y;	///< Tmp debug data
 } flow_t;
 
 
+/**
+ * \brief Init function
+ * 
+ * \param flow 		Pointer to flow structure
+ * \param UID  		Uart ID
+ * \param usart_conf 	Uart config
+ */
 void flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf);
 
+
+/**
+ * \brief Update function
+ * 
+ * \param flow 		Pointer to flow structure
+ */
 void flow_update(flow_t* flow);
+
 
 #ifdef __cplusplus
 }

--- a/runtime/scheduler_telemetry.c
+++ b/runtime/scheduler_telemetry.c
@@ -42,7 +42,8 @@
 
 #include "scheduler_telemetry.h"
 #include "time_keeper.h"
-
+#include "maths.h"
+ 
 void scheduler_telemetry_send_rt_stats(const scheduler_t* scheduler, const mavlink_stream_t* mavlink_stream, mavlink_message_t* msg)
 {
 	task_entry_t* stab_task = scheduler_get_task_by_id(scheduler,0);
@@ -60,7 +61,7 @@ void scheduler_telemetry_send_rt_stats(const scheduler_t* scheduler, const mavli
 										msg,
 										time_keeper_get_millis(),
 										"stabDelayVar",
-										sqrt(stab_task->delay_var_squared));
+										maths_fast_sqrt(stab_task->delay_var_squared));
 	mavlink_stream_send(mavlink_stream, msg);
 
 	mavlink_msg_named_value_float_pack(	mavlink_stream->sysid,


### PR DESCRIPTION
- Fix bug in mavlink stream, allow more than one instance of mavlink
- Add driver for uart optic flow sensor

Tested on epuck with:
- one main instance of mavlink_stream (in mavlink_communication) talking with the ground station,
- 2 instances of mavlink_stream receiving data from two cameras 

No changes needed in project files (unless a second mavlink_stream was created).