### PR TITLE
PX4Flow

### DIFF
--- a/communication/mavlink_stream.c
+++ b/communication/mavlink_stream.c
@@ -84,6 +84,11 @@ bool mavlink_stream_init(	mavlink_stream_t* mavlink_stream,
 		success = false;
 	}
 
+	if( success == true )
+	{
+		print_util_dbg_print("[MAVLINK STREAM] Initialized\r\n");	
+	}
+
 	return success;
 }
 

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -213,8 +213,7 @@ bool flow_update(flow_t* flow)
 							}
 
 							// swap bytes
-							// for (int i = 0; i < flow->of_count; ++i)
-							for (int i = 0; i < 125; ++i)
+							for (int i = 0; i < flow->of_count; ++i)
 							{
 								flow->of.x[i] = endian_rev16(flow->of_tmp.x[i]);
 								flow->of.y[i] = endian_rev16(flow->of_tmp.y[i]);

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -41,7 +41,7 @@
 
 #include "flow.h"
 #include "time_keeper.h"
-
+#include "print_util.h"
 
 //------------------------------------------------------------------------------
 // PRIVATE FUNCTIONS IMPLEMENTATION
@@ -88,6 +88,12 @@ bool flow_init(flow_t* flow, int32_t UID, usart_config_t usart_conf)
 					&mavlink_stream_conf,
 					&(flow->uart_stream_in),
 					&(flow->uart_stream_out));
+
+
+	if( success == true )
+	{
+		print_util_dbg_print("[Flow] Initialized\r\n");	
+	}
 
 	return success;
 }

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -210,8 +210,8 @@ bool flow_update(flow_t* flow)
 							// for (int i = 0; i < flow->of_count; ++i)
 							// for (int i = 0; i < 125; ++i)
 							// {
-								// flow->of.x[i] = endian_rev16(flow->of.x[i]);
-								// flow->of.y[i] = endian_rev16(flow->of.y[i]);
+							// 	flow->of.x[i] = endian_rev16(flow->of.x[i]);
+							// 	flow->of.y[i] = endian_rev16(flow->of.y[i]);
 							// }
 						}
 					break;

--- a/drivers/flow.c
+++ b/drivers/flow.c
@@ -190,12 +190,6 @@ bool flow_update(flow_t* flow)
 					break;
 
 					default:
-						/*if( data_msg.seqnr == 51 )
-						{
-							int16_t tmp1 = endian_rev16(flow->of.x[20]); 
-							int16_t tmp2 = endian_rev16(flow->of.x[50]);
-						}
-						*/
 						if( data_msg.seqnr < (flow->n_packets - 1) )
 						{
 							// not last packet


### PR DESCRIPTION
This fixes a bug in the reception of data from the px4flow. The 16 bits values were sent before the byte-swap.

No project-specific change.