### PR TITLE
Removed call to stdio.h

### DIFF
--- a/communication/data_logging.c
+++ b/communication/data_logging.c
@@ -603,8 +603,8 @@ bool data_logging_open_new_log_file(data_logging_t* data_logging)
 			// Add extension (.txt) to name_n_extension
 			data_logging_filename_append_extension(data_logging->name_n_extension, data_logging->name_n_extension);
 
-			// Check if there was enough memory allocated to name_n_extension
-			if (is_string_terminated(data_logging->name_n_extension, data_logging->buffer_name_size))
+			// Check if there wasn't enough memory allocated to name_n_extension
+			if (!is_string_terminated(data_logging->name_n_extension, data_logging->buffer_name_size))
 			{
 				print_util_dbg_print("Name error: The name is too long! It should be, with the extension, maximum ");
 				print_util_dbg_print_num(data_logging->buffer_name_size,10);

--- a/communication/data_logging.c
+++ b/communication/data_logging.c
@@ -403,6 +403,49 @@ static void data_logging_f_seek(data_logging_t* data_logging)
 	}
 }
 
+/*
+* \brief Appends a uint32_t to a character string with an underscore between.
+*
+* \param output		The output character string
+* \param filename	The input string
+* \param num		The uint32_t to be appended to filename
+*/
+void data_logging_filename_append_int(char* output, char* filename, uint32_t num)
+{
+	// Declare counter for char location
+	int i = 0;
+
+	while (filename[i] != '\0') // Copy characters to output from filename until
+								// null character is reached
+	{
+		output[i] = filename[i];
+		i++;
+	}
+
+	// Add underscore
+	output[i] = '_';
+	i++; // Update i for the num loop too
+
+	// Reverse order of num
+	uint32_t rev_num = 0;
+	while (num != 0)
+	{
+		rev_num *= 10; // Multiply by ten to move digit
+		rev_num += (num % 10); // Add 
+		num = num / 10; // Remove digit from num
+	}
+
+	do // Remove digits right to left adding them to output
+	{
+		output[i] = (rev_num % 10) + '0';
+		rev_num = rev_num / 10;
+		i++;
+	} while (rev_num != 0); // Stop when rev_num has gone through all the digits
+
+	// Add null character
+	output[i] = '\0';
+}
+
 //------------------------------------------------------------------------------
 // PUBLIC FUNCTIONS IMPLEMENTATION
 //------------------------------------------------------------------------------

--- a/communication/data_logging.c
+++ b/communication/data_logging.c
@@ -45,7 +45,6 @@
 #include "time_keeper.h"
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <math.h>
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I wrote three functions to replace the call to stdio.h with snprintf. This should solve Issue #126. They are:

data_logging_filename_append_int,
data_logging_filename_append_extension,
is_string_terminated

The is_string_terminated was created to continue doing the error checking that the snprintf allowed. I wasn't able to test the changes made to the previous code but the functions themselves seem to be working. A possible issue that I don't know if you care about is that if the file names are longer than allocated, the functions may try to write to data that wasn't created using malloc(). This can be fixed with setting data_logging->buffer_name_size properly, by adding an additional length parameter to the two functions, or by taking proper action if is_string_terminated fails.