### PR TITLE
data_logging_add_param_{bool, enum}

### DIFF
--- a/communication/data_logging.c
+++ b/communication/data_logging.c
@@ -813,6 +813,16 @@ task_return_t data_logging_update(data_logging_t* data_logging)
 	return TASK_RUN_SUCCESS;
 }
 
+bool data_logging_add_parameter_bool(data_logging_t* data_logging, bool * val, const char* param_name)
+{
+	return data_logging_add_parameter_uint8(data_logging, (uint8_t *) val, param_name);
+}
+
+bool data_logging_add_parameter_enum(data_logging_t* data_logging, void * val, const char* param_name)
+{
+	return data_logging_add_parameter_uint32(data_logging, (uint32_t *) val, param_name);
+}
+
 bool data_logging_add_parameter_uint8(data_logging_t* data_logging, uint8_t* val, const char* param_name)
 {
 	bool add_success = true;

--- a/communication/data_logging.h
+++ b/communication/data_logging.h
@@ -160,6 +160,28 @@ task_return_t data_logging_update(data_logging_t* data_logging);
  *
  * \return	True if the parameter was added, false otherwise
  */
+bool data_logging_add_parameter_bool(data_logging_t* data_logging, bool * val, const char* param_name);
+
+/**
+ * \brief	Registers parameter to log on the SD card. Parameter must take on values from an enum
+ *
+ * \param	data_logging			The pointer to the data logging structure
+ * \param 	val						The parameter value
+ * \param 	param_name				Name of the parameter
+ *
+ * \return	True if the parameter was added, false otherwise
+ */
+bool data_logging_add_parameter_enum(data_logging_t* data_logging, void * val, const char* param_name);
+
+/**
+ * \brief	Registers parameter to log on the SD card
+ *
+ * \param	data_logging			The pointer to the data logging structure
+ * \param 	val						The parameter value
+ * \param 	param_name				Name of the parameter
+ *
+ * \return	True if the parameter was added, false otherwise
+ */
 bool data_logging_add_parameter_uint8(data_logging_t* data_logging, uint8_t* val, const char* param_name);
 
 /**


### PR DESCRIPTION
Just a bit of syntactic sugar to avoid typecasting errors when logging boolean or enum values. Though it should seem 'obvious' which types to use, always best to prevent errors than to fix them :)

* `data_logging_add_parameter_bool` casts the value and adds it as a uint8
* `data_logging_add_parameter_enum` casts the value and adds it as a uint32 (optional : would it be necessary to check if the system is 32 / 16 / 8 bit or can we consider that the targets are all 32 bits @GregoireH ?)
 