### PR TITLE
Fixed yaw bug in simulation mode

### DIFF
--- a/control/velocity_controller_copter.cpp
+++ b/control/velocity_controller_copter.cpp
@@ -180,6 +180,15 @@ void velocity_controller_copter_update(velocity_controller_copter_t* controller)
 	// thrust_vector[Z] = - GRAVITY + pid_controller_update_dt( &controller->pid[Z], errors[Z], controller->ahrs->dt );	// should be multiplied by mass
 	thrust_vector[Z] = pid_controller_update_dt( &controller->pid[Z], errors[Z], controller->ahrs->dt );	// should be multiplied by mass
 
+
+	aero_attitude_t attitude_yaw_inverse = coord_conventions_quat_to_aero(controller->ahrs->qe);
+	attitude_yaw_inverse.rpy[0] = 0.0f;
+	attitude_yaw_inverse.rpy[1] = 0.0f;
+	attitude_yaw_inverse.rpy[2] = -attitude_yaw_inverse.rpy[2];
+	
+	quat_t q_rot = coord_conventions_quaternion_from_aero(attitude_yaw_inverse);
+	quaternions_rotate_vector(q_rot, thrust_vector, thrust_vector);
+
 	// Compute the norm of the thrust that should be applied
 	// thrust_norm = vectors_norm(thrust_vector);
 
@@ -191,7 +200,8 @@ void velocity_controller_copter_update(velocity_controller_copter_t* controller)
 	// Map thrust dir to attitude
 	controller->attitude_command->rpy[ROLL]  = maths_clip(thrust_vector[Y], 1);
 	controller->attitude_command->rpy[PITCH] = - maths_clip(thrust_vector[X], 1);
-	controller->attitude_command->rpy[YAW]   = 0.0f;
+	//controller->attitude_command->rpy[YAW]   = 0.0f;
+	controller->attitude_command->rpy[YAW]   = 1.7f;
 
 	aero_attitude_t attitude;
 	attitude.rpy[ROLL] 	= controller->attitude_command->rpy[ROLL]; 

--- a/simulation/dynamic_model_quad_diag.cpp
+++ b/simulation/dynamic_model_quad_diag.cpp
@@ -216,7 +216,7 @@ const std::array<float, 3>& Dynamic_model_quad_diag::acceleration_bf(void) const
 
 const std::array<float, 3>& Dynamic_model_quad_diag::velocity_lf(void) const
 {
-	return vel_bf_;
+	return vel_;
 }
 
 


### PR DESCRIPTION
This fixes the issue during simulation where the quadcopter would lose control when the yaw angle was anything other than 0°. The issue was with a function in the simulated gps returning the velocity in the wrong coordinate frame.

There are also modifications to velocity_controller_copter.cpp that allows the quad to have a different yaw angle set.