### PR TITLE
Makefile: Added detection of changes in header files to Makefiles

### DIFF
--- a/sample_projects/LEQuad/proj_avr32/Makefile
+++ b/sample_projects/LEQuad/proj_avr32/Makefile
@@ -337,7 +337,7 @@ PREPROC_OPT += -DUDD_ENABLE
 # ASSEMBLY COMPILER OPTIONS
 # ------------------------------------------------------------------------------
 AS = avr32-gcc
-ASFLAGS = -x assembler-with-cpp -c -mpart=uc3c1512c -mrelax 
+ASFLAGS = -x assembler-with-cpp -c -mpart=uc3c1512c -mrelax -MMD -MP
 
 # Include files from MAVRIC library and source folder
 ASFLAGS += -I.
@@ -350,7 +350,7 @@ ASFLAGS += ${SRCS_INC}
 CC = avr32-gcc
 CFLAGS  = -O3 -mhard-float -fdata-sections -muse-rodata-section -g2 -pg -p -Wall 
 CFLAGS += -mpart=uc3c1512c -c -std=gnu99 -Wstrict-prototypes -Wmissing-prototypes 
-CFLAGS += -Werror-implicit-function-declaration -Wpointer-arith -mrelax -MD -MP -MF
+CFLAGS += -Werror-implicit-function-declaration -Wpointer-arith -mrelax -MMD -MP
 # CFLAGS += -ffunction-sections
 CFLAGS += ${PREPROC_OPT}
 
@@ -366,7 +366,7 @@ CFLAGS += ${SRCS_INC}
 CXX = avr32-g++
 # CXXFLAGS  = -O3 -std=gnu++0x -mhard-float -fdata-sections -muse-rodata-section 
 CXXFLAGS  = -O3 -std=c++0x -mhard-float -fdata-sections -muse-rodata-section 
-CXXFLAGS += -g2 -pg -p -Wall -mpart=uc3c1512c -c -Wpointer-arith -mrelax -MD -MP -MF
+CXXFLAGS += -g2 -pg -p -Wall -mpart=uc3c1512c -c -Wpointer-arith -mrelax -MMD -MP
 # CXXFLAGS += -D_DEFAULT_SOURCE 
 # CXXFLAGS += -ffunction-sections
 CXXFLAGS += ${PREPROC_OPT}
@@ -385,8 +385,8 @@ SIZER = avr32-size
 
 OBJCOPYFLAGS = -R .eeprom -R .fuse -R .lock -R .signature
 
-LDFLAGS  = -nostartfiles -Wl,-Map="mavric.map" -Wl,--start-group -lm  
-LDGLAGS += -Wl,--end-group -L"src/asf/avr32/utils/libs/dsplib/at32ucr3fp/gcc"  
+LDFLAGS  = -nostartfiles -Wl,-Map="mavric.map" -lm
+LDGLAGS += -L"src/asf/avr32/utils/libs/dsplib/at32ucr3fp/gcc"
 LDFLAGS += -Wl,--gc-sections -mpart=uc3c1512c -Wl,--relax -Wl,-e,_trampoline
 
 # Include files from MAVRIC library and source folder
@@ -407,6 +407,12 @@ BUILD_DIR = build
 # Get the names of the .o files from .c and .cpp files
 OBJS += $(addprefix ${BUILD_DIR}/, $(addsuffix .o, $(basename $(LIB_SRCS))))
 OBJS += $(addprefix ${BUILD_DIR}/, $(addsuffix .o, $(basename $(SRCS))))
+
+# ------------------------------------------------------------------------------
+# DEPENDENCY FILES (*.d)
+# ------------------------------------------------------------------------------
+DEPS += $(addsuffix .d, $(basename $(OBJS)))	# create list of dependency files
+-include $(DEPS)								# include existing dependency files
 
 
 # ------------------------------------------------------------------------------
@@ -490,8 +496,10 @@ flash: ${PROJ_NAME}.elf
 
 .PHONY: clean rebuild
 clean:
-	@rm -f $(OBJS) $(PROJ_NAME).elf $(PROJ_NAME).hex $(PROJ_NAME).bin
+	@rm -f $(OBJS) $(PROJ_NAME).elf $(PROJ_NAME).hex $(PROJ_NAME).bin $(DEPS)
 	@rm -rf build/
 	@$(PRINT_OK)
 
 rebuild: clean proj
+
+.DEFAULT_GOAL := all

--- a/sample_projects/LEQuad/proj_linux/Makefile
+++ b/sample_projects/LEQuad/proj_linux/Makefile
@@ -145,7 +145,7 @@ LIB_SRCS += hal/linux/serial_linux_io.cpp
 # CC = gcc
 OBJCOPY = objcopy
 
-CFLAGS  = -g -O2 -Wall -std=gnu99
+CFLAGS  = -g -O2 -Wall -std=gnu99 -MMD -MP
 
 # Include files from MAVRIC library and source folder
 CFLAGS += -I.
@@ -157,7 +157,7 @@ CFLAGS += ${LIB_INC}
 # CXX = g++
 OBJCOPY = objcopy
 
-CXXFLAGS  = -g -O2 -Wall -std=c++11
+CXXFLAGS  = -g -O2 -Wall -std=c++11 -MMD -MP
 
 # Include files from MAVRIC library and source folder
 CXXFLAGS += -I.
@@ -179,6 +179,13 @@ BUILD_DIR = build
 
 # Get the names of the .o files from .c and .cpp files
 OBJS += $(addprefix ${BUILD_DIR}/, $(addsuffix .o, $(basename $(LIB_SRCS))))
+
+# ------------------------------------------------------------------------------
+# DEPENDENCY FILES (*.d)
+# ------------------------------------------------------------------------------
+DEPS += $(addsuffix .d, $(basename $(OBJS)))	# create list of dependency files
+-include $(DEPS)								# include existing dependency files
+
 
 # ------------------------------------------------------------------------------
 # COMMANDS FOR FANCY OUTPUT
@@ -231,8 +238,10 @@ ${BUILD_DIR}/%.o: ${MAVRIC_LIB}/%.cpp
 
 .PHONY: clean rebuild
 clean:
-	@rm -f $(OBJS)
+	@rm -f $(OBJS) $(DEPS)
 	@rm -rf build/
 	@$(PRINT_OK)
 
 rebuild: clean proj
+
+.DEFAULT_GOAL := all

--- a/sample_projects/LEQuad/proj_stm32/Makefile
+++ b/sample_projects/LEQuad/proj_stm32/Makefile
@@ -170,7 +170,7 @@ SIZER 	:= arm-none-eabi-size
 # ------------------------------------------------------------------------------
 # C COMPILER OPTIONS
 # ------------------------------------------------------------------------------
-CFLAGS	+= -O0 -g -std=gnu99
+CFLAGS	+= -O0 -g -std=gnu99 -MMD -MP
 CFLAGS	+= -Wall
 # CFLAGS	+= -Wextra -Wshadow -Wimplicit-function-declaration
 # CFLAGS	+= -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes
@@ -183,7 +183,7 @@ CFLAGS += ${LIB_INC}
 # ------------------------------------------------------------------------------
 # C++ COMPILER OPTIONS
 # ------------------------------------------------------------------------------
-CXXFLAGS	+= -O0 -g -std=c++11
+CXXFLAGS	+= -O0 -g -std=c++11 -MMD -MP
 CXXFLAGS	+= -Wall
 # CXXFLAGS	+= -Wextra -Wshadow -Wredundant-decls  -Weffc++
 CXXFLAGS	+= -fno-common -ffunction-sections -fdata-sections
@@ -196,7 +196,7 @@ CXXFLAGS += ${LIB_INC}
 # ------------------------------------------------------------------------------
 # C & C++ preprocessor common flags
 # ------------------------------------------------------------------------------
-CPPFLAGS	+= -MD
+CPPFLAGS	+= -MMD -MP
 CPPFLAGS	+= -Wall -Wundef
 CPPFLAGS	+= -I$(CM3_INCLUDE_DIR) $(CM3_DEFS)
 
@@ -232,6 +232,13 @@ BUILD_DIR = build
 
 # Get the names of the .o files from .c and .cpp files
 OBJS += $(addprefix ${BUILD_DIR}/, $(addsuffix .o, $(basename $(LIB_SRCS))))
+
+# ------------------------------------------------------------------------------
+# DEPENDENCY FILES (*.d)
+# ------------------------------------------------------------------------------
+DEPS += $(addsuffix .d, $(basename $(OBJS)))	# create list of dependency files
+-include $(DEPS)								# include existing dependency files
+
 
 # ------------------------------------------------------------------------------
 # COMMANDS FOR FANCY OUTPUT
@@ -294,8 +301,10 @@ flash: $(PROJ_NAME).bin
 
 .PHONY: clean rebuild
 clean:
-	@rm -f $(OBJS)
+	@rm -f $(OBJS) $(DEPS)
 	@rm -rf build/
 	@$(PRINT_OK)
 
 rebuild: clean all
+
+.DEFAULT_GOAL := all


### PR DESCRIPTION
Compilation now produces a dependency file (*.d) for each object file (*.o) containing all headers it depends on.
So if a header file is newer than an object file, the object files is recompiled.

Makefile of proj_avr, proj_linux and proj_stm32:
- Added compiler flags -MMD -MP to generate a dependecy file (*.d) for each object file (*.o)
- Removed compiler flags -MD -MF since they have similar goals as -MMD
- Removed --start-group and --end-group from compiler flags since only the math library was grouped by them
- Added include of dependency files
- Added .DEFAULT-GOAL: Since dependency files are included before 'all' target, this is required so that 'make' builds 'all' target