### PR TITLE
Gyro auto calib

### DIFF
--- a/communication/state_machine.hpp
+++ b/communication/state_machine.hpp
@@ -49,7 +49,7 @@
 #include "manual_control.hpp"
 #include "remote.hpp"
 #include "gps.hpp"
-
+#include "imu.hpp"
 
 /**
  * \brief Defines the state machine structure
@@ -60,6 +60,7 @@ typedef struct
 	State* state;										///< Pointer to the state structure
 	remote_t* remote;									///< Pointer to the remote structure
 	const Gps* gps;										///< Pointer to the gps structure
+	const Imu* imu;										///< Pointer to the imu structure
 	manual_control_t* manual_control;					///< Pointer to the manual_control structure
 } state_machine_t;
 
@@ -70,6 +71,7 @@ typedef struct
  * \param state_machine				Pointer to the state machine structure
  * \param state						Pointer to the state structure
  * \param gps 						Pointer to the gps structure
+ * \param imu 						Pointer to the imu structure
  * \param manual_control			Pointer to the manual_control structure
  *
  * \return	True if the init succeed, false otherwise
@@ -77,6 +79,7 @@ typedef struct
 bool state_machine_init(	state_machine_t *state_machine,
 							State* state,
 							const Gps* gps,
+							const Imu* imu,
 							manual_control_t* manual_control);
 
 /**

--- a/communication/state_telemetry.cpp
+++ b/communication/state_telemetry.cpp
@@ -113,35 +113,41 @@ void state_telemetry_set_mav_mode(State* state, uint32_t sysid, mavlink_message_
 		mav_mode_t new_mode;
 		new_mode = packet.base_mode;
 		
-		if ( mav_modes_is_armed(new_mode) )
+		if (state->mav_state == MAV_STATE_CALIBRATING)
 		{
-			if ( !mav_modes_is_armed(state->mav_mode)  )
-			{
-				state->switch_to_active_mode(&state->mav_state);
-			}
+			print_util_dbg_print("Currently calibrating, impossible to change mode.\r\n");
 		}
 		else
 		{
-			state->mav_state = MAV_STATE_STANDBY;
-		}
-		
-		// state->mav_mode.ARMED = new_mode.ARMED;
-		// state->mav_mode.MANUAL = new_mode.MANUAL;
-		// //state->mav_mode.HIL = new_mode.HIL;
-		// state->mav_mode.STABILISE = new_mode.STABILISE;
-		// state->mav_mode.GUIDED = new_mode.GUIDED;
-		// state->mav_mode.AUTO = new_mode.AUTO;
-		// state->mav_mode.TEST = new_mode.TEST;
-		// state->mav_mode.CUSTOM = new_mode.CUSTOM;
-		
-		state->mav_mode = (new_mode & (~MAV_MODE_FLAG_HIL_ENABLED)) + (state->mav_mode & MAV_MODE_FLAG_HIL_ENABLED);
+			if ( mav_modes_is_armed(new_mode) )
+			{
+				if ( !mav_modes_is_armed(state->mav_mode)  )
+				{
+					state->switch_to_active_mode(&state->mav_state);
+				}
+			}
+			else
+			{
+				state->mav_state = MAV_STATE_STANDBY;
+			}
 
-		//state->mav_mode_custom = packet.custom_mode;
-		
-		print_util_dbg_print("New mav mode:");
-		print_util_dbg_print_num(state->mav_mode,10);
-		print_util_dbg_print("\r");
-		
+			// state->mav_mode.ARMED = new_mode.ARMED;
+			// state->mav_mode.MANUAL = new_mode.MANUAL;
+			// //state->mav_mode.HIL = new_mode.HIL;
+			// state->mav_mode.STABILISE = new_mode.STABILISE;
+			// state->mav_mode.GUIDED = new_mode.GUIDED;
+			// state->mav_mode.AUTO = new_mode.AUTO;
+			// state->mav_mode.TEST = new_mode.TEST;
+			// state->mav_mode.CUSTOM = new_mode.CUSTOM;
+			
+			state->mav_mode = (new_mode & (~MAV_MODE_FLAG_HIL_ENABLED)) + (state->mav_mode & MAV_MODE_FLAG_HIL_ENABLED);
+
+			//state->mav_mode_custom = packet.custom_mode;
+			
+			print_util_dbg_print("New mav mode:");
+			print_util_dbg_print_num(state->mav_mode,10);
+			print_util_dbg_print("\r");
+		}
 	}
 }
 
@@ -151,40 +157,48 @@ static mav_result_t state_telemetry_set_mode_from_cmd(State* state, mavlink_comm
 	
 	mav_mode_t new_mode;
 	new_mode = packet->param1;
-	
-	print_util_dbg_print("base_mode from cmd:");
-	print_util_dbg_print_num(packet->param1,10);
-	//print_util_dbg_print(", custom mode:");
-	//print_util_dbg_print_num(packet->param2,10);
-	print_util_dbg_print("\r\n");
 
-	if ( mav_modes_is_armed(new_mode) )
+	if (state->mav_state == MAV_STATE_CALIBRATING)
 	{
-		if ( !mav_modes_is_armed(state->mav_mode) )
-		{
-			state->switch_to_active_mode(&state->mav_state);
-		}
+		result = MAV_RESULT_TEMPORARILY_REJECTED;
+		print_util_dbg_print("Currently calibrating, impossible to change mode.\r\n");
 	}
 	else
-	{
-		state->mav_state = MAV_STATE_STANDBY;
-	}
-	
-	state->mav_mode = (new_mode & (~MAV_MODE_FLAG_HIL_ENABLED)) + (state->mav_mode & MAV_MODE_FLAG_HIL_ENABLED);
+	{	
+		print_util_dbg_print("base_mode from cmd:");
+		print_util_dbg_print_num(packet->param1,10);
+		//print_util_dbg_print(", custom mode:");
+		//print_util_dbg_print_num(packet->param2,10);
+		print_util_dbg_print("\r\n");
 
-	// state->mav_mode.ARMED = new_mode.ARMED;
-	// state->mav_mode.MANUAL = new_mode.MANUAL;
-	// state->mav_mode.STABILISE = new_mode.STABILISE;
-	// state->mav_mode.GUIDED = new_mode.GUIDED;
-	// state->mav_mode.AUTO = new_mode.AUTO;
-	// state->mav_mode.TEST = new_mode.TEST;
-	// state->mav_mode.CUSTOM = new_mode.CUSTOM;
-	
-	//state->mav_mode_custom = packet->param2;
-	
-	print_util_dbg_print("New mav mode:");
-	print_util_dbg_print_num(state->mav_mode,10);
-	print_util_dbg_print("\r\n");
+		if ( mav_modes_is_armed(new_mode) )
+		{
+			if ( !mav_modes_is_armed(state->mav_mode) )
+			{
+				state->switch_to_active_mode(&state->mav_state);
+			}
+		}
+		else
+		{
+			state->mav_state = MAV_STATE_STANDBY;
+		}
+		
+		state->mav_mode = (new_mode & (~MAV_MODE_FLAG_HIL_ENABLED)) + (state->mav_mode & MAV_MODE_FLAG_HIL_ENABLED);
+
+		// state->mav_mode.ARMED = new_mode.ARMED;
+		// state->mav_mode.MANUAL = new_mode.MANUAL;
+		// state->mav_mode.STABILISE = new_mode.STABILISE;
+		// state->mav_mode.GUIDED = new_mode.GUIDED;
+		// state->mav_mode.AUTO = new_mode.AUTO;
+		// state->mav_mode.TEST = new_mode.TEST;
+		// state->mav_mode.CUSTOM = new_mode.CUSTOM;
+		
+		//state->mav_mode_custom = packet->param2;
+		
+		print_util_dbg_print("New mav mode:");
+		print_util_dbg_print_num(state->mav_mode,10);
+		print_util_dbg_print("\r\n");
+	}
 
 	return result;
 }

--- a/sample_projects/LEQuad/central_data.cpp
+++ b/sample_projects/LEQuad/central_data.cpp
@@ -131,6 +131,7 @@ bool Central_data::init(void)
 	ret = state_machine_init( 	&state_machine,
 								&state,
 								&gps,
+								&imu,
 								&manual_control);
 	print_util_dbg_init_msg("[STATE MACHINE]", ret);
 	init_success &= ret;

--- a/sensing/ahrs.c
+++ b/sensing/ahrs.c
@@ -74,7 +74,7 @@ bool ahrs_init(ahrs_t* ahrs)
 	ahrs->linear_acc[Y] = 0.0f;
 	ahrs->linear_acc[Z] = 0.0f;
 	
-	ahrs->internal_state = AHRS_INIT;
+	ahrs->internal_state = AHRS_INITIALISING;
 	
 	return init_success;
 }

--- a/sensing/ahrs.c
+++ b/sensing/ahrs.c
@@ -74,7 +74,7 @@ bool ahrs_init(ahrs_t* ahrs)
 	ahrs->linear_acc[Y] = 0.0f;
 	ahrs->linear_acc[Z] = 0.0f;
 	
-	ahrs->internal_state = AHRS_UNLEVELED;
+	ahrs->internal_state = AHRS_INIT;
 	
 	return init_success;
 }

--- a/sensing/ahrs.h
+++ b/sensing/ahrs.h
@@ -57,10 +57,10 @@ extern "C" {
  */
 typedef enum
 {
-	AHRS_INIT 		= 0,	///< Calibration level: No calibration, init
-	AHRS_UNLEVELED 	= 1,	///< Calibration level: No calibration, attitude estimation correction by accelero/magneto measurements
-	AHRS_CONVERGING = 2,	///< Calibration level: leveling, correction of gyro biais
-	AHRS_READY 		= 3,	///< Calibration level: leveled 
+	AHRS_INITIALISING 	= 0,	///< Calibration level: Not initialised
+	AHRS_LEVELING 		= 1,	///< Calibration level: No calibration, attitude estimation correction by accelero/magneto measurements
+	AHRS_CONVERGING 	= 2,	///< Calibration level: leveling, correction of gyro biais
+	AHRS_READY 			= 3,	///< Calibration level: leveled 
 } ahrs_state_t;
 
 

--- a/sensing/ahrs.h
+++ b/sensing/ahrs.h
@@ -57,9 +57,10 @@ extern "C" {
  */
 typedef enum
 {
-	AHRS_UNLEVELED 	= 0,	///< Calibration level: No calibration 
-	AHRS_CONVERGING = 1,	///< Calibration level: leveling 
-	AHRS_READY 		= 2,	///< Calibration level: leveled 
+	AHRS_INIT 		= 0,	///< Calibration level: No calibration, init
+	AHRS_UNLEVELED 	= 1,	///< Calibration level: No calibration, attitude estimation correction by accelero/magneto measurements
+	AHRS_CONVERGING = 2,	///< Calibration level: leveling, correction of gyro biais
+	AHRS_READY 		= 3,	///< Calibration level: leveled 
 } ahrs_state_t;
 
 

--- a/sensing/imu.cpp
+++ b/sensing/imu.cpp
@@ -298,9 +298,9 @@ void Imu::do_startup_calibration(void)
 		}
 
 		// Check if the gyroscope values are stable
-		bool gyro_is_stable = ( maths_f_abs(config_.gyroscope.mean_values[X] - scaled_gyro_[X]) < 0.5f )
-							&&( maths_f_abs(config_.gyroscope.mean_values[Y] - scaled_gyro_[Y]) < 0.5f )
-							&&( maths_f_abs(config_.gyroscope.mean_values[Z] - scaled_gyro_[Z]) < 0.5f );
+		bool gyro_is_stable = ( maths_f_abs(config_.gyroscope.mean_values[X] - scaled_gyro_[X]) < config_.startup_calib_gyro_threshold )
+							&&( maths_f_abs(config_.gyroscope.mean_values[Y] - scaled_gyro_[Y]) < config_.startup_calib_gyro_threshold )
+							&&( maths_f_abs(config_.gyroscope.mean_values[Z] - scaled_gyro_[Z]) < config_.startup_calib_gyro_threshold );
 
 		
 		if( gyro_is_stable == false )
@@ -311,7 +311,7 @@ void Imu::do_startup_calibration(void)
 		}
 
 		// If gyros have been stable for long enough
-		if( (gyro_is_stable == true) && ((time_keeper_get_s() - timestamp_gyro_stable) > 10.0f) )
+		if( (gyro_is_stable == true) && ((time_keeper_get_s() - timestamp_gyro_stable) > config_.startup_calib_duration_s) )
 		{
 			// Sartup calibration is done
 			is_ready_ = true;

--- a/sensing/imu.cpp
+++ b/sensing/imu.cpp
@@ -128,7 +128,7 @@ bool Imu::update(void)
 	{
 		for( uint8_t i=0; i<3; i++ )
 		{
-			config_.accelerometer.mean_values[i] = 0.5 * ( config_.accelerometer.mean_values[i] + scaled_acc_[i] );
+			config_.accelerometer.mean_values[i] = (1.0f - config_.lpf_mean) * config_.accelerometer.mean_values[i] + config_.lpf_mean * scaled_acc_[i];
 		}
 	}
 
@@ -155,7 +155,7 @@ bool Imu::update(void)
 				time_ready = time_keeper_get_s();
 			}
 
-			config_.gyroscope.mean_values[i] = 0.5f * (config_.gyroscope.mean_values[i] + scaled_gyro_[i] );
+			config_.gyroscope.mean_values[i] = (1.0f - config_.lpf_mean) * config_.gyroscope.mean_values[i] + config_.lpf_mean * scaled_gyro_[i];
 		}
 
 		if (going2ready)

--- a/sensing/imu.hpp
+++ b/sensing/imu.hpp
@@ -91,6 +91,8 @@ typedef struct
 	float lpf_gyro;						///< Low pass filter gain for accelerometer
 	float lpf_mag;						///< Low pass filter gain for accelerometer
 	float lpf_mean;						///< Low pass filter gain for the mean values
+	float startup_calib_gyro_threshold; ///< Threshold on gyroscope value used to decide wheter the autopilot is held stable
+	float startup_calib_duration_s;		///< Duration in seconds of the automatic startup calibration of gyroscopes
 } imu_conf_t;
 
 
@@ -421,6 +423,10 @@ static inline imu_conf_t imu_default_config()
 	conf.lpf_gyro 	= 0.05f;
 	conf.lpf_mag 	= 0.1f;
 	conf.lpf_mean 	= 0.01f;
+
+	// startup calibration length
+	conf.startup_calib_gyro_threshold = 0.5f;
+	conf.startup_calib_duration_s 	  = 10.0f;
 	
 	return conf;
 }

--- a/sensing/imu.hpp
+++ b/sensing/imu.hpp
@@ -169,7 +169,12 @@ public:
 	 */	
 	const std::array<float, 3>& mag(void) const;
 
-
+	/**
+	 * \brief 	Get the readiness of the IMU
+	 * 
+	 * \return 	True if the IMU is ready, false otherwise
+	 */	
+	const bool is_ready(void) const;
 
 	/**
 	 * \brief 	Temporary method to get pointer to configuration
@@ -284,9 +289,11 @@ private:
 	bool do_accelerometer_bias_calibration_;	///< Flag indicating if calibration should be done
 	bool do_gyroscope_bias_calibration_;		///< Flag indicating if calibration should be done
 	bool do_magnetometer_bias_calibration_;		///< Flag indicating if calibration should be done
+	bool is_ready_;								///< Flag indicating the readiness of the IMU
 
 	float dt_s_;						///< Time interval between two updates (in microseconds)
 	float last_update_us_;				///< Last update time in microseconds
+	float time_ready;					///< The time from which the gyroscope is not varying too much
 };
 
 

--- a/sensing/imu.hpp
+++ b/sensing/imu.hpp
@@ -90,6 +90,7 @@ typedef struct
 	float lpf_acc;						///< Low pass filter gain for accelerometer		
 	float lpf_gyro;						///< Low pass filter gain for accelerometer
 	float lpf_mag;						///< Low pass filter gain for accelerometer
+	float lpf_mean;						///< Low pass filter gain for the mean values
 } imu_conf_t;
 
 
@@ -401,6 +402,7 @@ static inline imu_conf_t imu_default_config()
 	conf.lpf_acc 	= 0.1f;
 	conf.lpf_gyro 	= 0.05f;
 	conf.lpf_mag 	= 0.1f;
+	conf.lpf_mean 	= 0.01f;
 	
 	return conf;
 }

--- a/sensing/imu.hpp
+++ b/sensing/imu.hpp
@@ -273,6 +273,24 @@ public:
 
 
 private:
+	/**
+	 * \brief 	Startup calibration
+	 * 
+	 * \detail 	Should not be used in flight
+	 * 			If the imu is not ready, this function waits for the gyroscopes 
+	 * 			values to be stable, then perform gyro bias calibration
+	 */
+	void do_startup_calibration(void);
+
+
+	/**
+	 * \brief 	Performs ongoing calibrations
+	 * 
+	 * \detail 	Should not be used in flight
+	 */
+	void do_calibration(void);
+
+
 	Accelerometer& 	accelerometer_;		///< Reference to accelerometer sensor
 	Gyroscope& 		gyroscope_;			///< Reference to gyroscope sensor
 	Magnetometer& 	magnetometer_;		///< Reference to magnetometer sensor
@@ -294,7 +312,7 @@ private:
 
 	float dt_s_;						///< Time interval between two updates (in microseconds)
 	float last_update_us_;				///< Last update time in microseconds
-	float time_ready;					///< The time from which the gyroscope is not varying too much
+	float timestamp_gyro_stable;		///< The time from which the gyroscope is not varying too much
 };
 
 

--- a/sensing/qfilter.cpp
+++ b/sensing/qfilter.cpp
@@ -184,10 +184,10 @@ void qfilter_update(qfilter_t *qf)
 	// get error correction gains depending on mode
 	switch (qf->ahrs->internal_state)
 	{
-		case AHRS_INIT:
+		case AHRS_INITIALISING:
 			qf->time_s = time_keeper_get_s();
-			qf->ahrs->internal_state = AHRS_UNLEVELED;
-		case AHRS_UNLEVELED:
+			qf->ahrs->internal_state = AHRS_LEVELING;
+		case AHRS_LEVELING:
 			kp = qf->kp * 10.0f;
 			kp_mag = qf->kp_mag * 10.0f;
 			

--- a/sensing/qfilter.cpp
+++ b/sensing/qfilter.cpp
@@ -86,7 +86,6 @@ bool qfilter_init(qfilter_t* qf, const qfilter_conf_t config, const Imu* imu, ah
 
 void qfilter_update(qfilter_t *qf)
 {
-	static uint32_t convergence_update_count = 0;
 	float  omc[3], omc_mag[3] , tmp[3], snorm, norm, s_acc_norm, acc_norm, s_mag_norm, mag_norm;
 	quat_t qed, qtmp1, up, up_bf;
 	quat_t mag_global, mag_corrected_local;
@@ -185,19 +184,21 @@ void qfilter_update(qfilter_t *qf)
 	// get error correction gains depending on mode
 	switch (qf->ahrs->internal_state)
 	{
+		case AHRS_INIT:
+			qf->time_s = time_keeper_get_s();
+			qf->ahrs->internal_state = AHRS_UNLEVELED;
 		case AHRS_UNLEVELED:
 			kp = qf->kp * 10.0f;
 			kp_mag = qf->kp_mag * 10.0f;
 			
-			ki = 0.5f * qf->ki;
-			ki_mag = 0.5f * qf->ki_mag;
+			ki = 0.0f * qf->ki;
+			ki_mag = 0.0f * qf->ki_mag;
 			
-			convergence_update_count += 1;
-			if( convergence_update_count > 2000 )
+			if ( (time_keeper_get_s() - qf->time_s) > 8.0f )
 			{
-				convergence_update_count = 0;
+				qf->time_s = time_keeper_get_s();
 				qf->ahrs->internal_state = AHRS_CONVERGING;
-				print_util_dbg_print("[QFILTER] End of AHRS attitude initialization.\r\n");
+				print_util_dbg_print("End of AHRS attitude initialization.\r\n");
 			}
 			break;
 			
@@ -205,15 +206,13 @@ void qfilter_update(qfilter_t *qf)
 			kp = qf->kp;
 			kp_mag = qf->kp_mag;
 			
-			ki = qf->ki * 3.0f;
-			ki_mag = qf->ki_mag * 3.0f;
+			//ki = qf->ki * 1.5f;
+			//ki_mag = qf->ki_mag * 1.5f;
 			
-			convergence_update_count += 1;
-			if( convergence_update_count > 2000 )
+			if ( qf->imu->is_ready() )
 			{
-				convergence_update_count = 0;
 				qf->ahrs->internal_state = AHRS_READY;
-				print_util_dbg_print("[QFILTER] End of AHRS leveling.\r\n");
+				print_util_dbg_print("End of AHRS leveling.\r\n");
 			}
 			break;
 

--- a/sensing/qfilter.hpp
+++ b/sensing/qfilter.hpp
@@ -74,6 +74,8 @@ typedef struct
 	float   ki;				///< The integral gain for the acceleration correction of the biais
 	float   kp_mag;			///< The proportional gain for the magnetometer correction of the angular rates
 	float   ki_mag;			///< The integral gain for the magnetometer correction of the angular rates
+
+	float time_s;			///< The time keeper to swtich between the internal states
 	
 	std::array<float,3> 	gyro_bias;	///< Gyro bias compensation
 } qfilter_t;

--- a/sensing/qfilter_default_config.h
+++ b/sensing/qfilter_default_config.h
@@ -53,7 +53,7 @@ static inline qfilter_conf_t qfilter_default_config()
 {
 	qfilter_conf_t conf = {};
 	conf.kp             = 0.07f;
-	conf.ki             = 0.07f / 15.0f;
+	conf.ki             = 0.0f;
 	conf.kp_mag         = 0.1f;
 	conf.ki_mag         = 0.0f;
 


### PR DESCRIPTION
Implementation of a strategy to calibrate the bias of the gyroscope at startup when the robot is stable on the ground. 
Avoid arming of the motors while the calibration is not finish. 
qFilter is not correcting the bias anymore. 