### PR TITLE
Autocalibration at startup

### DIFF
--- a/hal/include/gyroscope.h
+++ b/hal/include/gyroscope.h
@@ -52,6 +52,7 @@ typedef struct
 	float data[3];			///< The gyroscope's datas
 	float temperature;		///< The gyroscope's temperature
 	float last_update;		///< The gyroscope last update time
+	float data_lpf[3];		///< The gyroscope's data low-pass filtered
 } gyroscope_t;
 
 #endif /* GYRO_H_ */

--- a/sensing/ahrs.c
+++ b/sensing/ahrs.c
@@ -74,7 +74,7 @@ bool ahrs_init(ahrs_t* ahrs)
 	ahrs->linear_acc[Y] = 0.0f;
 	ahrs->linear_acc[Z] = 0.0f;
 	
-	ahrs->internal_state = AHRS_UNLEVELED;
+	ahrs->internal_state = AHRS_INIT;
 
 	ahrs->north_vec.s    = 0.0f;
 	ahrs->north_vec.v[X] = 1.0f;

--- a/sensing/ahrs.h
+++ b/sensing/ahrs.h
@@ -57,9 +57,10 @@ extern "C" {
  */
 typedef enum
 {
-	AHRS_UNLEVELED 	= 0,	///< Calibration level: No calibration 
-	AHRS_CONVERGING = 1,	///< Calibration level: leveling 
-	AHRS_READY 		= 2,	///< Calibration level: leveled 
+	AHRS_INIT 		= 0,	///< Calibration level: No calibration, init
+	AHRS_UNLEVELED 	= 1,	///< Calibration level: No calibration, attitude estimation correction by accelero/magneto measurements
+	AHRS_CONVERGING = 2,	///< Calibration level: leveling, correction of gyro biais
+	AHRS_READY 		= 3,	///< Calibration level: leveled 
 } ahrs_state_t;
 
 

--- a/sensing/imu.h
+++ b/sensing/imu.h
@@ -126,6 +126,9 @@ typedef struct
 	float dt;								///< The time interval between two IMU updates
 	uint32_t last_update;					///< The time of the last IMU update in ms
 
+	bool imu_ready;
+	uint32_t time_ready;
+
 	state_t* state;							///< The pointer to the state structure
 } imu_t;
 

--- a/sensing/qfilter.h
+++ b/sensing/qfilter.h
@@ -70,11 +70,13 @@ typedef struct
 {
 	imu_t* 	imu;			///< Pointer to inertial sensors readout
 	ahrs_t* ahrs;			///< Pointer to estimated attiude
-	
+
 	float   kp;				///< The proportional gain for the acceleration correction of the angular rates
 	float   ki;				///< The integral gain for the acceleration correction of the biais
 	float   kp_mag;			///< The proportional gain for the magnetometer correction of the angular rates
 	float   ki_mag;			///< The integral gain for the magnetometer correction of the angular rates
+
+	uint32_t time_ms;		///< The time keeper to swtich between the internal states
 } qfilter_t;
 
 

--- a/sensing/qfilter_default_config.h
+++ b/sensing/qfilter_default_config.h
@@ -51,8 +51,8 @@ extern "C" {
 
 static const qfilter_conf_t qfilter_default_config =
 {
-    .kp = 0.07f,
-    .ki = 0.07f / 15.0f,
+    .kp = 0.15f,
+    .ki = 0.0f,//0.1f / 15.0f,
     .kp_mag = 0.1f,
     .ki_mag = 0.0f,
 };


### PR DESCRIPTION
Backport automatic gyro startup calibration to 1.5.x branch.

@ndousse I prefer to have a single branch for the releases following 1.5.0 (ie. branch **release/1.5.x**). If this is tested and is enough for a new release, you can create a release (here **v1.5.1**) pointing to the last commit of the branch **release/1.5.x**
Do you agree?