### PR TITLE
run linux simulation on windows using cygwin

### DIFF
--- a/doc/docs/98_Pages_From_Wiki/Run-linux-simulation-in-Windows.md
+++ b/doc/docs/98_Pages_From_Wiki/Run-linux-simulation-in-Windows.md
@@ -1,0 +1,13 @@
+This part explains how to run the linux simulation of the mavric in windows using cygwin.
+
+## 1. Install Cygwin
+Download [cygwin](https://www.cygwin.com/) for your operating system (32 or 64 bits). NB: The following was working on win7 64bits.
+Install cygwin and be sure to have the following packages included:
+- Devel / "binutils"
+- Devel / "gcc-g++" & "gcc-core"
+- Devel / "make"
+
+## 2. Compile and run the simulation
+Open Cygwin and go to the folder of the Makefile (type 'cd /cygdrive/C' to go in C:/) and type 'make' to compile it.
+- It compiles the code and produces and .elf file as output. 
+- Then type './xyz.elf' to run the file (here named xyz).

--- a/doc/docs/98_Pages_From_Wiki/Setup-on-Windows.md
+++ b/doc/docs/98_Pages_From_Wiki/Setup-on-Windows.md
@@ -17,7 +17,12 @@ The code edition and the compiling can be both made from Atmel Studio. For this,
 # Using Eclipse and Cygwin
 The possibility allows you to compile using the Makefile used in linux. Follow the instructions.
 - Download [Eclipse](http://www.eclipse.org/downloads/packages/eclipse-ide-cc-developers/marsr)
-- Download [Cygwin](https://www.cygwin.com/). Take care to download the packages that can runs the 'make' commands ("Devel" section, find the make package and take it). Some recommended packages are found on this [page](http://www.dogsbodynet.com/openr/install_cygwin.html) - part 9.
+- Download [Cygwin](https://www.cygwin.com/).
+
+Be sure to have the following packages included:
+- Devel / "binutils"
+- Devel / "gcc-g++" & "gcc-core"
+- Devel / "make"
 
 The Makefile will call 'avr-g++' or 'avr-gcc' to compile. These functions must be made global in windows to be called.
 - Add the link 'C:\Program Files (x86)\Atmel\Atmel Toolchain\AVR32 GCC\Native\3.4.2.435\avr32-gnu-toolchain\bin' into your Environment Variables. This link depends on your installation folder.


### PR DESCRIPTION
hey hey windows friends!
Now you can run the linux simulation on windows using cygwin. 
It uses the makefile and all the code intact as if you had linux.