### PR TITLE
No SD card return

### DIFF
--- a/hal/avr32/fat_fs_mounting_telemetry.c
+++ b/hal/avr32/fat_fs_mounting_telemetry.c
@@ -43,6 +43,7 @@
 #include "fat_fs_mounting_telemetry.h"
 #include "time_keeper.h"
 #include "print_util.h"
+#include "delay.h"
 
 /**
  * \brief	Toggle the fat_fs_mounting
@@ -67,13 +68,33 @@ static mav_result_t fat_fs_mounting_telemetry_toggle_logging(fat_fs_mounting_t* 
 		if(packet->param1 == 1)
 		{
 			print_util_dbg_print("Start logging from command message\r\n");
+
+			fat_fs_mounting_mount(fat_fs_mounting,true);
+
+			delay_ms(250);
+
+			if (fat_fs_mounting->sys_mounted)
+			{
+				result = MAV_RESULT_ACCEPTED;
+
+				print_util_dbg_print("Mounting successful\r\n");
+			}
+			else
+			{
+				result = MAV_RESULT_DENIED;
+				print_util_dbg_print("Mounting failed\r\n");
+			}
+
+			delay_ms(250);
 		}
 		else
 		{
 			print_util_dbg_print("Stop logging from command message\r\n");
+			fat_fs_mounting->loop_count = 0;
+
+			result = MAV_RESULT_ACCEPTED;
 		}
-	
-		result = MAV_RESULT_ACCEPTED;
+		
 	
 		fat_fs_mounting->log_data = packet->param1;
 	}

--- a/hal/avr32/fat_fs_mounting_telemetry.c
+++ b/hal/avr32/fat_fs_mounting_telemetry.c
@@ -43,7 +43,6 @@
 #include "fat_fs_mounting_telemetry.h"
 #include "time_keeper.h"
 #include "print_util.h"
-#include "delay.h"
 
 /**
  * \brief	Toggle the fat_fs_mounting
@@ -71,8 +70,6 @@ static mav_result_t fat_fs_mounting_telemetry_toggle_logging(fat_fs_mounting_t* 
 
 			fat_fs_mounting_mount(fat_fs_mounting,true);
 
-			delay_ms(250);
-
 			if (fat_fs_mounting->sys_mounted)
 			{
 				result = MAV_RESULT_ACCEPTED;
@@ -84,8 +81,6 @@ static mav_result_t fat_fs_mounting_telemetry_toggle_logging(fat_fs_mounting_t* 
 				result = MAV_RESULT_DENIED;
 				print_util_dbg_print("Mounting failed\r\n");
 			}
-
-			delay_ms(250);
 		}
 		else
 		{


### PR DESCRIPTION
When there is no SD card, the telemetery message returns false. 