### PR TITLE
Fix clockwise vs counter-clockwise rotations

### DIFF
--- a/control/servos_mix_quadcopter_diag_default_config.hpp
+++ b/control/servos_mix_quadcopter_diag_default_config.hpp
@@ -50,10 +50,10 @@ static inline servos_mix_quadcopter_diag_conf_t servos_mix_quadcopter_diag_defau
 {
     servos_mix_quadcopter_diag_conf_t conf  = {};
 
-    conf.motor_front_right_dir              = CW;
-    conf.motor_front_left_dir               = CCW;
-    conf.motor_rear_right_dir               = CCW;
-    conf.motor_rear_left_dir                = CW;
+    conf.motor_front_right_dir              = CCW;
+    conf.motor_front_left_dir               = CW;
+    conf.motor_rear_right_dir               = CW;
+    conf.motor_rear_left_dir                = CCW;
     conf.min_thrust                         = -0.9f;
     conf.max_thrust                         = 1.0f;
 

--- a/util/constants.h
+++ b/util/constants.h
@@ -102,8 +102,8 @@ typedef enum
  */
 typedef enum
 {
-    CW  = 1,                    ///< Clock wise
-    CCW = -1                    ///< Counter Clock wise
+    CCW =  1,                    ///< Counter Clock wise
+    CW  = -1                     ///< Clock wise
 } rot_dir_t;
 
 


### PR DESCRIPTION
With the default config, the motor directions configured in servos_mix_quadcopter_diag do not match the real quad !
- fix default servo mix config
- invert CW and CCW signs