### PR TITLE
Barometer: fix estimation problem when barometer is calibrated

### DIFF
--- a/drivers/barometer.cpp
+++ b/drivers/barometer.cpp
@@ -81,7 +81,8 @@ const float& Barometer::temperature(void) const
 
 void Barometer::calibrate_bias(float current_altitude_gf)
 {
-    altitude_bias_gf_ += (altitude_gf_ - current_altitude_gf);
+    altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
+    altitude_gf_ = current_altitude_gf;
 }
 
 

--- a/drivers/barometer.hpp
+++ b/drivers/barometer.hpp
@@ -137,6 +137,7 @@ protected:
     float pressure_;            ///< Measured pressure
     float temperature_;         ///< Measured temperature
     float altitude_gf_;         ///< Measured altitude (global frame)
+    float altitude_filtered;   ///< Measured altitude without bias removal
     float altitude_bias_gf_;    ///< Offset of the barometer sensor for matching GPS altitude value
     float speed_lf_;            ///< Vario altitude speed (ned frame)
     float last_update_us_;      ///< Time of the last update of the barometer

--- a/simulation/barometer_sim.cpp
+++ b/simulation/barometer_sim.cpp
@@ -55,6 +55,7 @@ Barometer_sim::Barometer_sim(Dynamic_model& dynamic_model):
     pressure_           = 0.0f;
     temperature_        = 0.0f;
     altitude_gf_        = 0.0f;
+    altitude_filtered   = 0.0f;
     altitude_bias_gf_   = 0.0f;
     speed_lf_           = 0.0f;
     last_update_us_     = 0.0f;
@@ -82,12 +83,12 @@ bool Barometer_sim::update(void)
     if (dt_s > 0.0f)
     {
         // Get altitude
-        float new_altitude = dynamic_model_.position_gf().altitude;
+        float altitude_filtered_old = altitude_filtered;
+        altitude_filtered = dynamic_model_.position_gf().altitude;
 
         // Get variation of altitude
-        speed_lf_       = - (new_altitude - altitude_gf_) / dt_s;
-        // altitude_gf_     = new_altitude - altitude_bias_gf_;
-        altitude_gf_    = new_altitude;
+        speed_lf_       = - (altitude_filtered - altitude_filtered_old) / dt_s;
+        altitude_gf_    = altitude_filtered - altitude_bias_gf_;
 
         // Get pressure
         pressure_ = 0.0f; // TODO


### PR DESCRIPTION
Moved lowpass filter before the bias removal, so that it is not affected by calibration
This removes the spikes in altitude estimation observed at calibration