### PR TITLE
Raytracing

### DIFF
--- a/rules_common.mk
+++ b/rules_common.mk
@@ -79,4 +79,5 @@ LIB_SRCS += util/coord_conventions.c
 LIB_SRCS += util/matrix.cpp
 LIB_SRCS += util/print_util.c
 LIB_SRCS += util/quick_trig.c
+LIB_SRCS += util/raytracing.cpp
 LIB_SRCS += util/string_util.cpp

--- a/util/raytracing.cpp
+++ b/util/raytracing.cpp
@@ -179,6 +179,51 @@ bool Intersection::set_distance(float distance)
 }
 
 
+//##################################################################################################
+// World class
+//##################################################################################################
+bool World::add_object(Object* obj)
+{
+    bool success = false;
+
+    if (obj != NULL)
+    {
+        success = true;
+        objects_.push_back(obj);
+    }
+    else
+    {
+        success = false;
+    }
+
+    return success;
+}
+
+bool World::intersect(const Ray& ray, Intersection& intersection, Object* object)
+{
+    bool success = false;
+    Intersection inter_tmp;
+    uint32_t object_count = objects_.size();
+
+    intersection.set_distance(1000.0f);
+
+    for (uint32_t i = 0; i < object_count; i++)
+    {
+        if (objects_[i]->intersect(ray, inter_tmp))
+        {
+            success = true;
+            if (inter_tmp.distance() < intersection.distance())
+            {
+                // This intersection is the best
+                intersection = inter_tmp;
+            }
+        }
+    }
+
+    return success;
+}
+
+
 
 //##################################################################################################
 // Sphere class

--- a/util/raytracing.cpp
+++ b/util/raytracing.cpp
@@ -1,0 +1,383 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file raytracing.hpp
+ *
+ * \author MAV'RIC Team
+ * \author Julien Lecoeur
+ *
+ * \brief Raytracing. Implements rays and intersection with objects (plane, sphere, cylinder... )
+ *
+ ******************************************************************************/
+
+#include "util/raytracing.hpp"
+
+namespace raytracing
+{
+
+extern "C"
+{
+#include "util/maths.h"
+}
+
+float norm(Vector3f& vector)
+{
+    return maths_fast_sqrt( vector[0]*vector[0]
+                          + vector[1]*vector[1]
+                          + vector[2]*vector[2] );
+}
+
+float dot(const Vector3f& v1, const Vector3f& v2)
+{
+    return (v1.transpose() % v2)[0];
+}
+
+
+void cross(const Vector3f& v1, const Vector3f& v2, Vector3f& v)
+{
+    v[0] = v1[1] * v2[2] - v1[2] * v2[1];
+    v[1] = v1[2] * v2[0] - v1[0] * v2[2];
+    v[2] = v1[0] * v2[1] - v1[1] * v2[0];
+}
+
+//##################################################################################################
+// Ray class
+//##################################################################################################
+
+Ray::Ray(Vector3f origin, Vector3f direction):
+    origin_(origin)
+{
+    // Normalize direction
+    set_direction(direction);
+}
+
+const Vector3f& Ray::origin(void) const
+{
+    return origin_;
+}
+
+bool Ray::set_origin(Vector3f origin)
+{
+    origin_ = origin;
+
+    return true;
+}
+
+const Vector3f& Ray::direction(void) const
+{
+    return direction_;
+}
+
+bool Ray::set_direction(Vector3f direction)
+{
+    bool success = false;
+    float magnitude = norm(direction);
+
+    if (magnitude != 0.0f)
+    {
+        direction_[0] = direction[0] / magnitude;
+        direction_[1] = direction[1] / magnitude;
+        direction_[2] = direction[2] / magnitude;
+        success = true;
+    }
+    else
+    {
+        success = false;
+    }
+
+    return success;
+}
+
+
+//##################################################################################################
+// Intersection class
+//##################################################################################################
+Intersection::Intersection(Vector3f point, Vector3f normal, float distance):
+    point_(point),
+    distance_(distance)
+{
+    set_normal(normal);
+}
+
+const Vector3f& Intersection::point(void) const
+{
+    return point_;
+}
+
+
+bool Intersection::set_point(Vector3f point)
+{
+    point_ = point;
+    return true;
+}
+
+
+const Vector3f& Intersection::normal(void) const
+{
+    return normal_;
+}
+
+bool Intersection::set_normal(Vector3f normal)
+{
+    bool success = false;
+    float magnitude = norm(normal);
+
+    if (magnitude != 0.0f)
+    {
+        normal_[0] = normal[0] / magnitude;
+        normal_[1] = normal[1] / magnitude;
+        normal_[2] = normal[2] / magnitude;
+        success = true;
+    }
+    else
+    {
+        success = false;
+    }
+
+    return success;
+}
+
+
+float Intersection::distance(void) const
+{
+    return distance_;
+}
+
+bool Intersection::set_distance(float distance)
+{
+    distance_ = maths_f_abs(distance);
+    return true;
+}
+
+
+
+//##################################################################################################
+// Sphere class
+//##################################################################################################
+Sphere::Sphere(Vector3f center, float radius):
+  center_(center),
+  radius_(radius)
+{}
+
+const Vector3f& Sphere::center(void) const
+{
+    return center_;
+}
+
+
+bool Sphere::set_center(Vector3f center)
+{
+    center_ = center;
+
+    return true;
+}
+
+
+float Sphere::radius(void) const
+{
+    return radius_;
+}
+
+
+bool Sphere::set_radius(float radius)
+{
+    radius_ = maths_f_abs(radius);
+
+    return true;
+}
+
+
+bool Sphere::intersect(const Ray& ray, Intersection& intersection)
+{
+    bool success = false;
+
+    // Vector CO from  sphere center (C) to ray origin (O)
+    Vector3f co = ray.origin() - center_;
+
+    float q = dot(ray.direction(), co) * dot(ray.direction(), co)
+              - dot(co, co)
+              + radius_ * radius_;
+
+    if (q < 0)
+    {
+        // No intersection
+        success = false;
+    }
+    else
+    {
+        float d  = - dot(ray.direction(), co);
+        float d1 = d - maths_fast_sqrt(q);
+        float d2 = d + maths_fast_sqrt(q);
+
+        if ( (0.0f < d1) && ((d1 < d2) || (d2 < 0.0f)) )
+        {
+            success = true;
+            intersection.set_point(ray.origin() + ray.direction() * d1);
+            intersection.set_distance(d1);
+            intersection.set_normal(intersection.point() - center_);
+        }
+        else if ( (0.0f < d2) && ((d2 < d1) || (d1 < 0.0f)) )
+        {
+            success = true;
+            intersection.set_point(ray.origin() + ray.direction() * d2);
+            intersection.set_distance(d2);
+            intersection.set_normal(intersection.point() - center_);
+        }
+        else
+        {
+            // No intersection
+            success = false;
+        }
+    }
+
+    return success;
+}
+
+
+//##################################################################################################
+// Cylinder class
+//##################################################################################################
+Cylinder::Cylinder(Vector3f center, Vector3f axis, float radius):
+  center_(center),
+  radius_(radius)
+{
+    set_axis(axis);
+}
+
+const Vector3f& Cylinder::center(void) const
+{
+    return center_;
+}
+
+
+bool Cylinder::set_center(Vector3f center)
+{
+    center_ = center;
+
+    return true;
+}
+
+
+float Cylinder::radius(void) const
+{
+    return radius_;
+}
+
+
+bool Cylinder::set_radius(float radius)
+{
+    radius_ = maths_f_abs(radius);
+
+    return true;
+}
+
+
+const Vector3f& Cylinder::axis(void) const
+{
+    return axis_;
+}
+
+
+bool Cylinder::set_axis(Vector3f axis)
+{
+    bool success = false;
+    float magnitude = norm(axis);
+
+    if (magnitude != 0.0f)
+    {
+        axis_[0] = axis[0] / magnitude;
+        axis_[1] = axis[1] / magnitude;
+        axis_[2] = axis[2] / magnitude;
+        success = true;
+    }
+    else
+    {
+        success = false;
+    }
+
+    return success;
+}
+
+
+bool Cylinder::intersect(const Ray& ray, Intersection& intersection)
+{
+    bool success = false;
+
+    Vector3f alpha   = axis_ * dot(ray.direction(), axis_);
+    Vector3f deltaP  = ray.origin() - center_;
+    Vector3f beta    = axis_ * dot(deltaP, axis_);
+
+    float a = dot(ray.direction() - alpha, ray.direction() - alpha);
+    float b = 2 * dot(ray.direction() - alpha, deltaP - beta);
+    float c = dot(deltaP - beta, deltaP - beta) - radius_*radius_;
+
+    float discriminant = b*b - 4*a*c;
+
+    if (discriminant < 0)
+    {
+        // No intersection
+        success = false;
+    }
+    else
+    {
+        discriminant = sqrt(discriminant);
+        float d1 = ((-1 * b) + discriminant) / (2 * a);
+        float d2 = ((-1 * b) - discriminant) / (2 * a);
+        if ((0.0f < d1) && ((d1 < d2) || (d2 < 0.0f)))
+        {
+              // Use d1
+              success = true;
+              intersection.set_point(ray.origin() + ray.direction() * d1);
+              intersection.set_distance(d1);
+              Vector3f cp = intersection.point() - center_;
+              intersection.set_normal( cp - axis_ * dot(axis_, cp) );
+        }
+        else if ((0.0f < d2) && ((d2 < d1) || (d1 < 0.0f)))
+        {
+              // Use d2
+              success = true;
+              intersection.set_point(ray.origin() + ray.direction() * d2);
+              intersection.set_distance(d2);
+              Vector3f cp = intersection.point() - center_;
+              intersection.set_normal( cp - axis_ * dot(axis_, cp) );
+        }
+        else
+        {
+              // No intersection
+              success = false;
+        }
+    }
+
+    return success;
+}
+
+}

--- a/util/raytracing.cpp
+++ b/util/raytracing.cpp
@@ -224,6 +224,88 @@ bool World::intersect(const Ray& ray, Intersection& intersection, Object* object
 }
 
 
+//##################################################################################################
+// Plane class
+//##################################################################################################
+Plane::Plane(Vector3f center, Vector3f normal):
+  center_(center)
+{
+    set_normal(normal);
+}
+
+const Vector3f& Plane::center(void) const
+{
+    return center_;
+}
+
+
+bool Plane::set_center(Vector3f center)
+{
+    center_ = center;
+
+    return true;
+}
+
+
+const Vector3f& Plane::normal(void) const
+{
+    return normal_;
+}
+
+
+bool Plane::set_normal(Vector3f normal)
+{
+    bool success = false;
+    float magnitude = norm(normal);
+
+    if (magnitude != 0.0f)
+    {
+        normal_[0] = normal[0] / magnitude;
+        normal_[1] = normal[1] / magnitude;
+        normal_[2] = normal[2] / magnitude;
+        success = true;
+    }
+    else
+    {
+        success = false;
+    }
+
+    return success;
+}
+
+
+bool Plane::intersect(const Ray& ray, Intersection& intersection)
+{
+    bool success = false;
+
+    float den = dot(ray.direction(), normal_);
+
+    if (den != 0.0f)
+    {
+        float d = dot(center_ - ray.origin(), normal_) / den;
+
+        if ( d > 0.0f )
+        {
+            success = true;
+            intersection.set_point(ray.origin() + ray.direction() * d);
+            intersection.set_distance(d);
+            intersection.set_normal(ray.origin() - intersection.point());
+        }
+        else
+        {
+            // No intersection
+            success = false;
+        }
+    }
+    else
+    {
+        // No intersection
+        success = false;
+    }
+
+    return success;
+}
+
 
 //##################################################################################################
 // Sphere class

--- a/util/raytracing.cpp
+++ b/util/raytracing.cpp
@@ -182,17 +182,31 @@ bool Intersection::set_distance(float distance)
 //##################################################################################################
 // World class
 //##################################################################################################
+World::World(void):
+  object_count_(0)
+{}
+
 bool World::add_object(Object* obj)
 {
     bool success = false;
 
     if (obj != NULL)
     {
-        success = true;
-        objects_.push_back(obj);
+        if (object_count_ < objects_.size())
+        {
+            success = true;
+            objects_[object_count_] = obj;
+            object_count_ += 1;
+        }
+        else
+        {
+            // Too many objects
+            success = false;
+        }
     }
     else
     {
+        // Invalid object
         success = false;
     }
 

--- a/util/raytracing.hpp
+++ b/util/raytracing.hpp
@@ -178,6 +178,11 @@ class World
 {
 public:
     /**
+     * \brief   Constructor
+     */
+    World(void);
+
+    /**
      * \brief   Add an object to the world
      *
      * \param   obj     Object
@@ -198,7 +203,8 @@ public:
     bool intersect(const Ray& ray, Intersection& intersection, Object* object);
 
 private:
-    std::vector<Object*>  objects_;
+    std::array<Object*, 20>  objects_;
+    uint32_t                 object_count_;
 };
 
 

--- a/util/raytracing.hpp
+++ b/util/raytracing.hpp
@@ -1,0 +1,291 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file raytracing.hpp
+ *
+ * \author MAV'RIC Team
+ * \author Julien Lecoeur
+ *
+ * \brief Raytracing. Implements rays and intersection with objects (plane, sphere, cylinder... )
+ *
+ ******************************************************************************/
+
+
+#ifndef RAYTRACING_HPP_
+#define RAYTRACING_HPP_
+
+#include "util/matrix.hpp"
+
+namespace raytracing
+{
+
+
+//##################################################################################################
+// Ray class
+//##################################################################################################
+/**
+ * \brief   Ray
+ */
+class Ray
+{
+public:
+    /**
+     * \brief   Constructor
+     *
+     * \param   origin      Ray origin
+     * \param   direction   Ray direction (unit vector)
+     */
+    Ray(Vector3f origin, Vector3f direction);
+
+    /**
+     * \brief   Return origin point
+     */
+    const Vector3f& origin(void) const;
+
+    /**
+     * \brief   Update origin point
+     */
+    bool set_origin(Vector3f origin);
+
+    /**
+     * \brief   Return direction vector
+     */
+    const Vector3f& direction(void) const;
+
+    /**
+     * \brief   Update direction
+     */
+    bool set_direction(Vector3f origin);
+
+private:
+    Vector3f origin_;           ///< Ray origin
+    Vector3f direction_;        ///< Ray
+};
+
+
+//##################################################################################################
+// Intersection class
+//##################################################################################################
+/**
+ * \brief Intersection betwen a ray and an object
+ */
+class Intersection
+{
+public:
+    /**
+     * \brief   Constructor
+     *
+     * \param   point       Intersection point
+     * \param   normal      Normal to surface at intersection
+     * \param   distance    Distance from intersection point to ray origin
+     */
+    Intersection(Vector3f point = Vector3f{0.0f, 0.0f, 0.0f}, Vector3f normal = Vector3f{1.0f, 0.0f, 0.0f}, float distance = 0.0f);
+
+    /**
+     * \brief   Return intersection point
+     */
+    const Vector3f& point(void) const;
+
+    /**
+     * \brief   Update intersection point
+     */
+    bool set_point(Vector3f point);
+
+    /**
+     * \brief   Return normal vector
+     */
+    const Vector3f& normal(void) const;
+
+    /**
+     * \brief   Update normal
+     */
+    bool set_normal(Vector3f normal);
+
+    /**
+     * \brief   Return distance
+     */
+    float distance(void) const;
+
+    /**
+     * \brief   Update normal
+     */
+    bool set_distance(float distance);
+
+private:
+      Vector3f point_;     ///< Intersection point
+      Vector3f normal_;    ///< Normal to surface at intersection
+      float distance_;     ///< Distance from intersection point to ray origin
+};
+
+
+//##################################################################################################
+// Object interface
+//##################################################################################################
+/**
+ * \brief   Object interface
+ */
+class Raytracing_object
+{
+public:
+    /**
+     * \brief Perform intersection between a ray and the current object
+     *
+     * \param   ray           Ray to intersect with (input)
+     * \param   intersection  Intersection point (output)
+     *
+     * \return  boolean indicating if an intersection was found
+     */
+    virtual bool intersect(const Ray& ray, Intersection& intersection) = 0;
+};
+
+
+//##################################################################################################
+// Sphere class
+//##################################################################################################
+/**
+ * \brief   Sphere
+ */
+class Sphere: public Raytracing_object
+{
+public:
+    /**
+     * \brief   Constructor
+     *
+     * \param   center      Center of sphere
+     * \param   radius      Radius of sphere
+     */
+    Sphere(Vector3f center, float radius);
+
+    /**
+     * \brief   Return origin point
+     */
+    const Vector3f& center(void) const;
+
+    /**
+     * \brief   Update center point
+     */
+    bool set_center(Vector3f center);
+
+    /**
+     * \brief   Return radius vector
+     */
+    float radius(void) const;
+
+    /**
+     * \brief   Update radius
+     */
+    bool set_radius(float radius);
+
+    /**
+     * \brief Perform intersection between a ray and the current object
+     *
+     * \param   ray           Ray to intersect with (input)
+     * \param   intersection  Intersection point (output)
+     *
+     * \return  boolean indicating if an intersection was found
+     */
+    bool intersect(const Ray& ray, Intersection& intersection);
+
+private:
+    Vector3f center_;       ///< Center of sphere
+    float radius_;          ///< Radius of sphere
+};
+
+
+//##################################################################################################
+// Cylinder class
+//##################################################################################################
+/**
+ * \brief   Cylinder
+ */
+class Cylinder: public Raytracing_object
+{
+public:
+    /**
+     * \brief   Constructor
+     *
+     * \param   center      Center of cylinder
+     * \param   axis        Axis of the cylinder (normal vetor)
+     * \param   radius      Radius of cylinder
+     */
+    Cylinder(Vector3f center, Vector3f axis, float radius);
+
+    /**
+     * \brief   Return center point
+     */
+    const Vector3f& center(void) const;
+
+    /**
+     * \brief   Update center point
+     */
+    bool set_center(Vector3f center);
+
+    /**
+     * \brief   Return axis
+     */
+    const Vector3f& axis(void) const;
+
+    /**
+     * \brief   Update axis
+     */
+    bool set_axis(Vector3f axis);
+
+    /**
+     * \brief   Return radius vector
+     */
+    float radius(void) const;
+
+    /**
+     * \brief   Update radius
+     */
+    bool set_radius(float radius);
+
+    /**
+     * \brief Perform intersection between a ray and the current object
+     *
+     * \param   ray           Ray to intersect with (input)
+     * \param   intersection  Intersection point (output)
+     *
+     * \return  boolean indicating if an intersection was found
+     */
+    bool intersect(const Ray& ray, Intersection& intersection);
+
+private:
+    Vector3f center_;       ///< Center of sphere
+    Vector3f axis_;         ///< Axis of sphere
+    float radius_;          ///< Radius of sphere
+    // float height_;          ///< Height of cylinder
+};
+
+}
+
+#endif /* RAYTRACING_HPP_ */

--- a/util/raytracing.hpp
+++ b/util/raytracing.hpp
@@ -44,6 +44,7 @@
 #define RAYTRACING_HPP_
 
 #include "util/matrix.hpp"
+#include <vector>
 
 namespace raytracing
 {
@@ -64,7 +65,7 @@ public:
      * \param   origin      Ray origin
      * \param   direction   Ray direction (unit vector)
      */
-    Ray(Vector3f origin, Vector3f direction);
+    Ray(Vector3f origin = Vector3f{0.0f, 0.0f, 0.0f}, Vector3f direction = Vector3f{1.0f, 0.0f, 0.0f});
 
     /**
      * \brief   Return origin point
@@ -153,7 +154,7 @@ private:
 /**
  * \brief   Object interface
  */
-class Raytracing_object
+class Object
 {
 public:
     /**
@@ -167,6 +168,39 @@ public:
     virtual bool intersect(const Ray& ray, Intersection& intersection) = 0;
 };
 
+//##################################################################################################
+// World class
+//##################################################################################################
+/**
+ * \brief  World
+ */
+class World
+{
+public:
+    /**
+     * \brief   Add an object to the world
+     *
+     * \param   obj     Object
+     *
+     * \return  success
+     */
+    bool add_object(Object* obj);
+
+    /**
+     * \brief   Return intersection between ray and closest object in world
+     *
+     * \param   ray           Ray to intersect with (input)
+     * \param   intersection  Intersection point (output)
+     * \param   object        Intersecting object (output)
+     *
+     * \return  boolean indicating if an intersection was found
+     */
+    bool intersect(const Ray& ray, Intersection& intersection, Object* object);
+
+private:
+    std::vector<Object*>  objects_;
+};
+
 
 //##################################################################################################
 // Sphere class
@@ -174,7 +208,7 @@ public:
 /**
  * \brief   Sphere
  */
-class Sphere: public Raytracing_object
+class Sphere: public Object
 {
 public:
     /**
@@ -183,7 +217,7 @@ public:
      * \param   center      Center of sphere
      * \param   radius      Radius of sphere
      */
-    Sphere(Vector3f center, float radius);
+    Sphere(Vector3f center = Vector3f{0.0f, 0.0f, 0.0f}, float radius = 1.0f);
 
     /**
      * \brief   Return origin point
@@ -227,7 +261,7 @@ private:
 /**
  * \brief   Cylinder
  */
-class Cylinder: public Raytracing_object
+class Cylinder: public Object
 {
 public:
     /**
@@ -237,7 +271,7 @@ public:
      * \param   axis        Axis of the cylinder (normal vetor)
      * \param   radius      Radius of cylinder
      */
-    Cylinder(Vector3f center, Vector3f axis, float radius);
+    Cylinder(Vector3f center = Vector3f{0.0f, 0.0f, 0.0f}, Vector3f axis = Vector3f{0.0f, 0.0f, 1.0f}, float radius = 1.0f);
 
     /**
      * \brief   Return center point

--- a/util/raytracing.hpp
+++ b/util/raytracing.hpp
@@ -203,6 +203,59 @@ private:
 
 
 //##################################################################################################
+// Plane class
+//##################################################################################################
+/**
+ * \brief   Plane
+ */
+class Plane: public Object
+{
+public:
+    /**
+     * \brief   Constructor
+     *
+     * \param   center      Center of sphere
+     * \param   radius      Radius of sphere
+     */
+    Plane(Vector3f center = Vector3f{0.0f, 0.0f, 0.0f}, Vector3f normal = Vector3f{1.0f, 0.0f, 0.0f});
+
+    /**
+     * \brief   Return origin point
+     */
+    const Vector3f& center(void) const;
+
+    /**
+     * \brief   Update center point
+     */
+    bool set_center(Vector3f center);
+
+    /**
+     * \brief   Return origin point
+     */
+    const Vector3f& normal(void) const;
+
+    /**
+     * \brief   Update normal point
+     */
+    bool set_normal(Vector3f normal);
+
+    /**
+     * \brief Perform intersection between a ray and the current object
+     *
+     * \param   ray           Ray to intersect with (input)
+     * \param   intersection  Intersection point (output)
+     *
+     * \return  boolean indicating if an intersection was found
+     */
+    bool intersect(const Ray& ray, Intersection& intersection);
+
+private:
+    Vector3f center_;       ///< Center of plane
+    Vector3f normal_;       ///< Normal to plane
+};
+
+
+//##################################################################################################
 // Sphere class
 //##################################################################################################
 /**

--- a/util/raytracing.hpp
+++ b/util/raytracing.hpp
@@ -192,7 +192,7 @@ public:
     bool add_object(Object* obj);
 
     /**
-     * \brief   Return intersection between ray and closest object in world
+     * \brief   Perform intersection between ray and closest object in world
      *
      * \param   ray           Ray to intersect with (input)
      * \param   intersection  Intersection point (output)
@@ -236,12 +236,12 @@ public:
     bool set_center(Vector3f center);
 
     /**
-     * \brief   Return origin point
+     * \brief   Return normal vector
      */
     const Vector3f& normal(void) const;
 
     /**
-     * \brief   Update normal point
+     * \brief   Update normal vector
      */
     bool set_normal(Vector3f normal);
 


### PR DESCRIPTION
Raytracing related objects

example use:
```cpp
#include "util/raytracing.hpp"
[...]
// Create world
raytracing::World world;

// Add one cylinder
raytracing::Cylinder cyl(Vector3f{ 0.5f, 1.5f, 0.0f}, Vector3f{ 0.0f, 0.0f, 1.0f}, 1.0f);
world.add_object(&cyl);

// Add 4 vertical planes
raytracing::Plane p0(Vector3f{-20.0f, 0.0f, 0.0f}, Vector3f{1.0f, 0.0f, 0.0f});
raytracing::Plane p1(Vector3f{20.0f, 0.0f, 0.0f}, Vector3f{-1.0f, 0.0f, 0.0f});
raytracing::Plane p2(Vector3f{0.0f, -20.0f, 0.0f}, Vector3f{0.0f, 1.0f, 0.0f});
raytracing::Plane p3(Vector3f{0.0f, 20.0f, 0.0f}, Vector3f{0.0f, -1.0f, 0.0f});
world.add_object(&p0);
world.add_object(&p1);
world.add_object(&p2);
world.add_object(&p3);

// Create ray
raytracing::Ray(Vector3f{0.0f, 0.0f, 0.0f}, Vector3f{1.0f, 0.0f, 0.0f})

// Create objects for intersection
raytracing::Intersection inter_tmp;
raytracing::Object* obj_tmp = NULL;
bool hit;

// Intersect ray with objects
hit = world.intersect(ray, inter_tmp, obj);
```