### PR TITLE
Add callback for command REQUEST_AUTOPILOT_CAPABILITIES (ID 520)

### DIFF
--- a/communication/state.cpp
+++ b/communication/state.cpp
@@ -62,7 +62,8 @@ extern "C"
 // PUBLIC FUNCTIONS IMPLEMENTATION
 //------------------------------------------------------------------------------
 
-State::State(Battery& battery, state_conf_t config):
+State::State(mavlink_stream_t& mavlink_stream, Battery& battery, state_conf_t config):
+    mavlink_stream_(mavlink_stream),
     battery_(battery)
 {
     // Init parameters

--- a/communication/state.hpp
+++ b/communication/state.hpp
@@ -47,6 +47,7 @@
 #include <stdbool.h>
 
 #include "communication/mav_modes.hpp"
+#include "communication/mavlink_stream.hpp"
 #include "drivers/battery.hpp"
 
 
@@ -141,10 +142,11 @@ public:
     /**
      * \brief   Constructor
      *
+     * \param   mavlink_stream  Mavlink downlink
      * \param   battery         Battery monitor
      * \param   state_config    State configuration structure
      */
-    State(Battery& battery, state_conf_t config = state_default_config());
+    State(mavlink_stream_t& mavlink_stream_, Battery& battery, state_conf_t config = state_default_config());
 
 
     /**
@@ -196,7 +198,8 @@ public:
     bool connection_lost;                               ///< Flag to tell if we have connection with the GND station or not
     bool first_connection_set;                          ///< Flag to tell that we received a first message from the GND station
 
-    Battery& battery_;                                  ///< Pointer to battery structure
+    mavlink_stream_t&   mavlink_stream_;                ///< Mavlink communication, used to inform ground station of state and capabilities of drone
+    Battery&            battery_;                       ///< Pointer to battery structure
 };
 
 

--- a/sample_projects/LEQuad/central_data.cpp
+++ b/sample_projects/LEQuad/central_data.cpp
@@ -63,7 +63,7 @@ Central_data::Central_data(uint8_t sysid, Imu& imu, Barometer& barometer, Gps& g
     servo_1(servo_1),
     servo_2(servo_2),
     servo_3(servo_3),
-    state(battery, config.state_config),
+    state(mavlink_communication.mavlink_stream, battery, config.state_config),
     data_logging(file1, state, config.data_logging_config),
     data_logging2(file2, state, config.data_logging_config2),
     altitude_estimation_(sonar, barometer, ahrs, altitude_),


### PR DESCRIPTION
Dronekit requests autopilot capabilities (CMD 520) every second until the drone responds.

This PR adds a command callback to answer with the autopilot version and capabilities.