### PR TITLE
Added const to data logging function parameters

### DIFF
--- a/communication/data_logging.cpp
+++ b/communication/data_logging.cpp
@@ -705,7 +705,7 @@ bool Data_logging::stop(void)
 
 
 template<>
-bool Data_logging::add_field(uint8_t* val, const char* param_name)
+bool Data_logging::add_field(const uint8_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -751,7 +751,7 @@ bool Data_logging::add_field(uint8_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(int8_t* val, const char* param_name)
+bool Data_logging::add_field(const int8_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -797,7 +797,7 @@ bool Data_logging::add_field(int8_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(uint16_t* val, const char* param_name)
+bool Data_logging::add_field(const uint16_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -843,7 +843,7 @@ bool Data_logging::add_field(uint16_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(int16_t* val, const char* param_name)
+bool Data_logging::add_field(const int16_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -889,7 +889,7 @@ bool Data_logging::add_field(int16_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(uint32_t* val, const char* param_name)
+bool Data_logging::add_field(const uint32_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -935,7 +935,7 @@ bool Data_logging::add_field(uint32_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(int32_t* val, const char* param_name)
+bool Data_logging::add_field(const int32_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -981,7 +981,7 @@ bool Data_logging::add_field(int32_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(uint64_t* val, const char* param_name)
+bool Data_logging::add_field(const uint64_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -1027,7 +1027,7 @@ bool Data_logging::add_field(uint64_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(int64_t* val, const char* param_name)
+bool Data_logging::add_field(const int64_t* val, const char* param_name)
 {
     bool add_success = true;
 
@@ -1073,7 +1073,7 @@ bool Data_logging::add_field(int64_t* val, const char* param_name)
 
 
 template<>
-bool Data_logging::add_field(float* val, const char* param_name, uint32_t precision)
+bool Data_logging::add_field(const float* val, const char* param_name, uint32_t precision)
 {
     bool add_success = true;
 
@@ -1120,7 +1120,7 @@ bool Data_logging::add_field(float* val, const char* param_name, uint32_t precis
 
 
 template<>
-bool Data_logging::add_field(double* val, const char* param_name, uint32_t precision)
+bool Data_logging::add_field(const double* val, const char* param_name, uint32_t precision)
 {
     bool add_success = true;
 
@@ -1167,7 +1167,7 @@ bool Data_logging::add_field(double* val, const char* param_name, uint32_t preci
 
 
 template<>
-bool Data_logging::add_field(bool* val, const char* param_name)
+bool Data_logging::add_field(const bool* val, const char* param_name)
 {
     bool add_success = true;
 

--- a/communication/data_logging.hpp
+++ b/communication/data_logging.hpp
@@ -53,7 +53,7 @@
  */
 typedef struct
 {
-    double* param;                                              ///< Pointer to the parameter value
+    const double* param;                                              ///< Pointer to the parameter value
     char param_name[MAVLINK_MSG_PARAM_SET_FIELD_PARAM_ID_LEN];  ///< Parameter name composed of 16 characters
     mavlink_message_type_t data_type;                           ///< Parameter type
     uint8_t precision;                                          ///< Number of digit after the zero
@@ -146,7 +146,7 @@ public:
      * \return  True if the parameter was added, false otherwise
      */
     template<typename T>
-    bool add_field(T* val, const char* param_name);
+    bool add_field(const T* val, const char* param_name);
 
 
     /**
@@ -162,7 +162,7 @@ public:
      * \return  True if the parameter was added, false otherwise
      */
     template<typename T>
-    bool add_field(T* val, const char* param_name, uint32_t precision);
+    bool add_field(const T* val, const char* param_name, uint32_t precision);
 
 
 private:


### PR DESCRIPTION
Added const to Data_logging::add_field() value parameter, as well as the structure that holds the pointer.

This is necessary for logging private variables which are obtained from getters that return a constant reference.