### PR TITLE
Copter velocity controller

### DIFF
--- a/communication/remote.cpp
+++ b/communication/remote.cpp
@@ -554,4 +554,5 @@ void remote_get_velocity_command(const remote_t* remote, velocity_command_t* com
     command->xyz[X] = - 10.0f * scale * remote_get_pitch(remote);
     command->xyz[Y] =   10.0f * scale * remote_get_roll(remote);
     command->xyz[Z] = - 1.5f  * scale * remote_get_throttle(remote);
+    command->mode = VELOCITY_COMMAND_MODE_SEMI_LOCAL;
 }

--- a/control/control_command.h
+++ b/control/control_command.h
@@ -67,9 +67,9 @@ typedef enum
  */
 typedef enum
 {
-    VELOCITY_COMMAND_MODE_LOCAL         = 0,    ///< Local frame
-    VELOCITY_COMMAND_MODE_SEMI_LOCAL    = 1,    ///< Global frame rotated around vertical axis to match the X axis with the current heading of the UAV
-    VELOCITY_COMMAND_MODE_GLOBAL        = 2,    ///< Global frame
+    VELOCITY_COMMAND_MODE_BODY          = 0,    ///< Body frame
+    VELOCITY_COMMAND_MODE_SEMI_LOCAL    = 1,    ///< Lobal frame rotated around vertical axis to match the X axis with the current heading of the UAV
+    VELOCITY_COMMAND_MODE_LOCAL         = 2,    ///< Local NED frame
 } velocity_command_mode_t;
 
 

--- a/control/joystick.cpp
+++ b/control/joystick.cpp
@@ -270,6 +270,7 @@ void joystick_get_velocity_command(const joystick_t* joystick, velocity_command_
     command->xyz[X] = -10.0f * scale * joystick_get_pitch(joystick);
     command->xyz[Y] =  10.0f * scale * joystick_get_roll(joystick);
     command->xyz[Z] = -1.5f  * scale * joystick_get_throttle(joystick);
+    command->mode = VELOCITY_COMMAND_MODE_SEMI_LOCAL;
 }
 
 

--- a/control/vector_field_waypoint.cpp
+++ b/control/vector_field_waypoint.cpp
@@ -454,7 +454,7 @@ void vector_field_waypoint_update(vector_field_waypoint_t* vector_field)
     float pos_obj[3];
 
     // Re-init velocity command
-    vector_field->velocity_command->mode    = VELOCITY_COMMAND_MODE_GLOBAL;
+    vector_field->velocity_command->mode    = VELOCITY_COMMAND_MODE_LOCAL;
     vector_field->velocity_command->xyz[X]  = 0.0f;
     vector_field->velocity_command->xyz[Y]  = 0.0f;
     vector_field->velocity_command->xyz[Z]  = 0.0f;

--- a/control/velocity_controller_copter.cpp
+++ b/control/velocity_controller_copter.cpp
@@ -57,32 +57,32 @@ extern "C"
 //------------------------------------------------------------------------------
 
 /**
- * \brief Converts velocity command from local to global frame
+ * \brief Converts velocity command from body frame to local frame
  *
  * \param controller    Pointer to data structure
- * \param command[3]    Velocity command in global frame (output)
+ * \param command[3]    Velocity command in local frame (output)
  */
-static void get_velocity_command_from_local_to_global(const velocity_controller_copter_t* controller, float command[3]);
+static void get_velocity_command_from_body_to_local(const velocity_controller_copter_t* controller, float command[3]);
 
 
 /**
- * \brief Converts velocity command from semi-local frame to global frame
+ * \brief Converts velocity command from semi-local frame to local frame
  *
  * \details Semi local frame is global rotated around the vertical axis to match
  * the X axis with the current heading of the UAV
  *
  * \param controller    Pointer to data structure
- * \param command[3]    Velocity command in global frame (output)
+ * \param command[3]    Velocity command in local frame (output)
  *
  */
-static void get_velocity_command_from_semilocal_to_global(const velocity_controller_copter_t* controller, float command[3]);
+static void get_velocity_command_from_semilocal_to_local(const velocity_controller_copter_t* controller, float command[3]);
 
 
 //------------------------------------------------------------------------------
 // PRIVATE FUNCTIONS IMPLEMENTATION
 //------------------------------------------------------------------------------
 
-static void get_velocity_command_from_local_to_global(const velocity_controller_copter_t* controller, float command[3])
+static void get_velocity_command_from_body_to_local(const velocity_controller_copter_t* controller, float command[3])
 {
     quaternions_rotate_vector(quaternions_inverse(controller->ahrs->qe),
                               controller->velocity_command->xyz,
@@ -90,7 +90,7 @@ static void get_velocity_command_from_local_to_global(const velocity_controller_
 }
 
 
-static void get_velocity_command_from_semilocal_to_global(const velocity_controller_copter_t* controller, float command[3])
+static void get_velocity_command_from_semilocal_to_local(const velocity_controller_copter_t* controller, float command[3])
 {
     aero_attitude_t semilocal_frame_rotation;
     quat_t q_semilocal;
@@ -101,12 +101,11 @@ static void get_velocity_command_from_semilocal_to_global(const velocity_control
     semilocal_frame_rotation.rpy[PITCH] = 0.0f;
     semilocal_frame_rotation.rpy[YAW]   = heading;
 
-    // Get rotation quaternion from semilocal frame to global frame
+    // Get rotation quaternion from semilocal frame to local frame
     q_semilocal = coord_conventions_quaternion_from_aero(semilocal_frame_rotation);
 
-    // Rotate command from semilocal to global
-    quaternions_rotate_vector(quaternions_inverse(q_semilocal),     // TODO: Check why this is not "quaternions_inverse( q_semilocal )" here
-                              // quaternions_rotate_vector(     q_semilocal,
+    // Rotate command from semilocal to local
+    quaternions_rotate_vector(q_semilocal,
                               controller->velocity_command->xyz,
                               command);
 }
@@ -137,89 +136,64 @@ void velocity_controller_copter_init(velocity_controller_copter_t* controller, v
 
 void velocity_controller_copter_update(velocity_controller_copter_t* controller)
 {
-    float velocity_command_global[3];
+    float velocity_command_local[3];
     float errors[3];
     float thrust_vector[3];
-    // float thrust_norm;
-    // float thrust_dir[3];
 
     // Get the command velocity in global frame
     switch (controller->velocity_command->mode)
     {
-        case VELOCITY_COMMAND_MODE_LOCAL:
-            get_velocity_command_from_local_to_global(controller,
-                    velocity_command_global);
+        case VELOCITY_COMMAND_MODE_BODY:
+            get_velocity_command_from_body_to_local(controller,
+                    velocity_command_local);
             break;
 
         case VELOCITY_COMMAND_MODE_SEMI_LOCAL:
-            get_velocity_command_from_semilocal_to_global(controller,
-                    velocity_command_global);
+            get_velocity_command_from_semilocal_to_local(controller,
+                    velocity_command_local);
             break;
 
-        case VELOCITY_COMMAND_MODE_GLOBAL:
-            velocity_command_global[X] = controller->velocity_command->xyz[X];
-            velocity_command_global[Y] = controller->velocity_command->xyz[Y];
-            velocity_command_global[Z] = controller->velocity_command->xyz[Z];
+        case VELOCITY_COMMAND_MODE_LOCAL:
+            velocity_command_local[X] = controller->velocity_command->xyz[X];
+            velocity_command_local[Y] = controller->velocity_command->xyz[Y];
+            velocity_command_local[Z] = controller->velocity_command->xyz[Z];
             break;
 
         default:
-            velocity_command_global[X] = 0.0f;
-            velocity_command_global[Y] = 0.0f;
-            velocity_command_global[Z] = 0.0f;
+            velocity_command_local[X] = 0.0f;
+            velocity_command_local[Y] = 0.0f;
+            velocity_command_local[Z] = 0.0f;
             break;
     }
 
-    // Compute errors
-    errors[X] = velocity_command_global[X] - controller->pos_est->vel[X];
-    errors[Y] = velocity_command_global[Y] - controller->pos_est->vel[Y];
-    errors[Z] = velocity_command_global[Z] - controller->pos_est->vel[Z];       // WARNING: it was multiplied by (-1) in stabilisation_copter.c
+    // Compute errors in local NED frame
+    errors[X] = velocity_command_local[X] - controller->pos_est->vel[X];
+    errors[Y] = velocity_command_local[Y] - controller->pos_est->vel[Y];
+    errors[Z] = velocity_command_local[Z] - controller->pos_est->vel[Z];       // WARNING: it was multiplied by (-1) in stabilisation_copter.c
 
-    // Update PID
+    // Update PID in local frame
     thrust_vector[X] = pid_controller_update_dt(&controller->pid[X], errors[X], controller->ahrs->dt_s);                // should be multiplied by mass
     thrust_vector[Y] = pid_controller_update_dt(&controller->pid[Y], errors[Y], controller->ahrs->dt_s);                // should be multiplied by mass
-    // thrust_vector[Z] = - GRAVITY + pid_controller_update_dt( &controller->pid[Z], errors[Z], controller->ahrs->dt ); // should be multiplied by mass
     thrust_vector[Z] = pid_controller_update_dt(&controller->pid[Z], errors[Z], controller->ahrs->dt_s);                // should be multiplied by mass
 
-
-    aero_attitude_t attitude_yaw_inverse = coord_conventions_quat_to_aero(controller->ahrs->qe);
+    // Rotate thrust vector to next semi_local frame
+    aero_attitude_t attitude_yaw_inverse;
     attitude_yaw_inverse.rpy[0] = 0.0f;
     attitude_yaw_inverse.rpy[1] = 0.0f;
-    attitude_yaw_inverse.rpy[2] = -attitude_yaw_inverse.rpy[2];
-
+    attitude_yaw_inverse.rpy[2] = -controller->attitude_command->rpy[YAW];
     quat_t q_rot = coord_conventions_quaternion_from_aero(attitude_yaw_inverse);
     quaternions_rotate_vector(q_rot, thrust_vector, thrust_vector);
-
-    // Compute the norm of the thrust that should be applied
-    // thrust_norm = vectors_norm(thrust_vector);
-
-    // Compute the direction in which thrust should be apply
-    // thrust_dir[X] = thrust_vector[X] / thrust_norm;
-    // thrust_dir[Y] = thrust_vector[Y] / thrust_norm;
-    // thrust_dir[Z] = thrust_vector[Z] / thrust_norm;
 
     // Map thrust dir to attitude
     controller->attitude_command->rpy[ROLL]  = maths_clip(thrust_vector[Y], 1);
     controller->attitude_command->rpy[PITCH] = - maths_clip(thrust_vector[X], 1);
-    //controller->attitude_command->rpy[YAW]   = 0.0f;
-    controller->attitude_command->rpy[YAW]   = 1.7f;
+    // controller->attitude_command->rpy[YAW]   = UNTOUCHED;
 
     aero_attitude_t attitude;
     attitude.rpy[ROLL]  = controller->attitude_command->rpy[ROLL];
     attitude.rpy[PITCH] = controller->attitude_command->rpy[PITCH];
     attitude.rpy[YAW]   = controller->attitude_command->rpy[YAW];
     controller->attitude_command->quat = coord_conventions_quaternion_from_aero(attitude);
-
-    // Map PID output to thrust
-    // float max_thrust = 30.0f;            // 10 Newton max thrust
-    // controller->thrust_command->thrust   = maths_clip(thrust_norm/max_thrust, 1.0f) * 2.0f - 1;
-    // controller->thrust_command->thrust   = maths_clip(thrust_norm, 1.0f) * 2.0f - 1;
-    // controller->thrust_command->thrust   = - 1.0 + 2 * thrust_norm/max_thrust;
-
-    // // Map PID output to attitude
-    // controller->attitude_command->mode        = ATTITUDE_COMMAND_MODE_RPY;
-    // controller->attitude_command->rpy[ROLL]  = maths_clip(thrust_vector[Y], 1);
-    // controller->attitude_command->rpy[PITCH] = - maths_clip(thrust_vector[X], 1);
-    // controller->attitude_command->rpy[YAW]   = 0.0f;
 
     // Map PID output to thrust
     controller->thrust_command->thrust  = controller->thrust_hover_point - thrust_vector[Z];

--- a/sample_projects/LEQuad/tasks.cpp
+++ b/sample_projects/LEQuad/tasks.cpp
@@ -165,40 +165,39 @@ bool tasks_run_stabilisation_quaternion(Central_data* central_data)
     }
     else if (state.is_auto())
     {
-        // vector_field_waypoint_update(&central_data->vector_field_waypoint);
-        // velocity_controller_copter_update(&central_data->velocity_controller);
-        // attitude_controller_update(&central_data->attitude_controller);
-        // servos_mix_quadcopter_diag_update(&central_data->servo_mix);
+        // Get command from vector field
+        vector_field_waypoint_update(&central_data->vector_field_waypoint);
+
+        // Do control
+        velocity_controller_copter_update(&central_data->velocity_controller);
+        attitude_controller_update(&central_data->attitude_controller);
+
+        // Write output
+        servos_mix_quadcopter_diag_update(&central_data->servo_mix);
     }
     else if (state.is_manual() && state.is_guided())
     {
-        // manual_control_get_velocity_command(&central_data->manual_control, &central_data->command.velocity, 1.0f);
-        // velocity_controller_copter_update(&central_data->velocity_controller);
-
-        // get attitude command from remote
+        // Get command from remote
         central_data->manual_control.get_attitude_command(0.02f, &central_data->command.attitude, 1.0f);
-
-        // Hardcode altitude command
-        central_data->command.position.xyz[0] = 0.0f;
-        central_data->command.position.xyz[1] = 0.0f;
-        central_data->command.position.xyz[2] = -5.0f;
-        central_data->command.position.mode   = POSITION_COMMAND_MODE_LOCAL;
+        central_data->manual_control.get_velocity_command(&central_data->command.velocity, 1.0f);
 
         // Do control
-        central_data->altitude_controller_.update();
+        velocity_controller_copter_update(&central_data->velocity_controller);
         attitude_controller_update(&central_data->attitude_controller);
 
+        // Write output
         servos_mix_quadcopter_diag_update(&central_data->servo_mix);
     }
     else if (state.is_manual() && state.is_stabilize())
     {
-        // get command from remote
+        // Get command from remote
         central_data->manual_control.get_attitude_command(0.02f, &central_data->command.attitude, 1.0f);
         central_data->manual_control.get_thrust_command(&central_data->command.thrust);
 
         // Do control
         attitude_controller_update(&central_data->attitude_controller);
 
+        // Write output
         servos_mix_quadcopter_diag_update(&central_data->servo_mix);
     }
     else


### PR DESCRIPTION
This controller was keeping the quad facing north, it now works in all directions. This does not affect stabilisation copter, it was used in the TP with vector field navigation.