### PR TITLE
Change default parameters of EKF

### DIFF
--- a/control/control_command.h
+++ b/control/control_command.h
@@ -157,7 +157,7 @@ typedef struct
 {
     control_command_mode_t  mode;       ///< Control command mode
     thrust_command_t        thrust;     ///< Thrust command
-    thrust3D_command_t      thrust3D;   ///< Thrust command
+    thrust3D_command_t      thrust3D;   ///< 3D Thrust command
     torque_command_t        torque;     ///< Torque command
     rate_command_t          rate;       ///< Rate command
     attitude_command_t      attitude;   ///< Attitude command

--- a/control/control_command.h
+++ b/control/control_command.h
@@ -146,7 +146,7 @@ typedef struct
  */
 typedef struct
 {
-    float thrust[3];
+    float xyz[3];
 } thrust3D_command_t;
 
 
@@ -157,6 +157,7 @@ typedef struct
 {
     control_command_mode_t  mode;       ///< Control command mode
     thrust_command_t        thrust;     ///< Thrust command
+    thrust3D_command_t      thrust3D;   ///< Thrust command
     torque_command_t        torque;     ///< Torque command
     rate_command_t          rate;       ///< Rate command
     attitude_command_t      attitude;   ///< Attitude command

--- a/sensing/ahrs_ekf.hpp
+++ b/sensing/ahrs_ekf.hpp
@@ -151,7 +151,6 @@ Ahrs_ekf::conf_t Ahrs_ekf::default_config()
     conf.sigma_w_sqr = 0.0000000001f;
     conf.sigma_r_sqr = 0.000001f;
     conf.R_acc = 0.004f;
-    // conf.R_mag = 0.020f;
     conf.R_mag = 0.040f;
     conf.acc_norm_noise = 0.05f;
     conf.acc_multi_noise = 4.0f;

--- a/sensing/ahrs_ekf.hpp
+++ b/sensing/ahrs_ekf.hpp
@@ -151,7 +151,8 @@ Ahrs_ekf::conf_t Ahrs_ekf::default_config()
     conf.sigma_w_sqr = 0.0000000001f;
     conf.sigma_r_sqr = 0.000001f;
     conf.R_acc = 0.004f;
-    conf.R_mag = 0.007f;
+    // conf.R_mag = 0.020f;
+    conf.R_mag = 0.040f;
     conf.acc_norm_noise = 0.05f;
     conf.acc_multi_noise = 4.0f;
 


### PR DESCRIPTION
Increased magnetometer noise from 0.007 to 0.040.
This way the MAV levels much better, it follows more the accelerometer. It hovers much better even if the magnetometer bias is not 100% perfect.