### PR TITLE
Fix i2c devices on avr32 (7bits/8bits addresses)

### DIFF
--- a/hal/avr32/i2c_avr32.cpp
+++ b/hal/avr32/i2c_avr32.cpp
@@ -100,7 +100,8 @@ bool I2c_avr32::probe(uint32_t address)
 {
     status_code_t status;
     //using 7bits addressing instead of 8bits R/W formating
-    status = twim_probe(twim_, address>>1);
+    // status = twim_probe(twim_, address>>1);
+    status = twim_probe(twim_, address);
     return status_code_to_bool(status);
 }
 
@@ -109,7 +110,8 @@ bool I2c_avr32::write(const uint8_t* buffer, uint32_t nbytes, uint32_t address)
 {
     status_code_t status;
     // atmel's implementation of TWIM uses 7bits address (no R/W bit), so we shift the 8 bit address
-    status = twim_write(twim_, buffer, nbytes, address>>1, config_.tenbit);
+    // status = twim_write(twim_, buffer, nbytes, address>>1, config_.tenbit);
+    status = twim_write(twim_, buffer, nbytes, address, config_.tenbit);
     return status_code_to_bool(status);
 }
 
@@ -118,7 +120,8 @@ bool I2c_avr32::read(uint8_t* buffer, uint32_t nbytes, uint32_t address)
 {
     status_code_t status;
     // atmel's implementation of TWIM uses 7bits address (no R/W bit), so we shift the 8 bit address
-    status = twim_read(twim_, buffer, nbytes, address>>1, config_.tenbit);
+    // status = twim_read(twim_, buffer, nbytes, address>>1, config_.tenbit);
+    status = twim_read(twim_, buffer, nbytes, address, config_.tenbit);
     return status_code_to_bool(status);
 }
 


### PR DESCRIPTION
Hot fix after #264 .

IMU sensors are not properly responding. I think this is because of an issue with the address not being correct.

See issue #267

