### PR TITLE
update for 7bits addressing and fixing bug on sonar for avr32 platform

### DIFF
--- a/drivers/hmc5883l.cpp
+++ b/drivers/hmc5883l.cpp
@@ -61,6 +61,7 @@ const uint8_t MEASUREMENT_CONTINUOUS  = 0x00;       ///< Continuous measurement 
 const uint8_t MEASUREMENT_SINGLE_SHOT = 0x01;       ///< Single Shot measurement Mode
 const uint8_t MEASUREMENT_IDLE        = 0x03;           ///< Idle Mode
 
+//using 7bits addressing instead of 8bits R/W format
 const uint8_t HMC5883_SLAVE_ADDRESS   = 0x1E;       ///< HMC5883L
 
 

--- a/drivers/lsm330dlc.cpp
+++ b/drivers/lsm330dlc.cpp
@@ -50,6 +50,7 @@ extern "C"
 #include "hal/common/time_keeper.hpp"
 }
 
+//using 7bits addressing instead of 8bits R/W format
 const uint8_t LSM330_ACC_SLAVE_ADDRESS      =   0b0011000;  ///< Define the Accelerometer Address, as a slave on the i2c bus
 const uint8_t LSM330_GYRO_SLAVE_ADDRESS     =   0b1101010;  ///< Define the Gyroscope Address, as a slave on the i2c bus
 

--- a/drivers/mpu_6050.cpp
+++ b/drivers/mpu_6050.cpp
@@ -45,7 +45,8 @@
 #include "hal/common/time_keeper.hpp"
 
 
-const uint8_t MPU_6050_ADDRESS      = 0xD0;
+//using 7bits addressing instead of 8bits R/W format
+const uint8_t MPU_6050_ADDRESS      = 0x68;
 const uint8_t WHO_ARE_YOU_COMMAND   = 0x75;
 const uint8_t I_AM_MPU_6050         = 0x68;
 const uint8_t MPU_6050_GET_ACC      = 0x3B;

--- a/drivers/sonar_i2cxl.hpp
+++ b/drivers/sonar_i2cxl.hpp
@@ -189,7 +189,8 @@ static inline sonar_i2cxl_conf_t sonar_i2cxl_default_config()
 {
     sonar_i2cxl_conf_t conf = {};
 
-    conf.i2c_address  = 0xE0;
+    //using 7bits addressing instead of 8bits R/W format
+    conf.i2c_address  = 0x70;
 
     // Correct range between 20cm and 7m, - safety
     conf.min_distance = 0.22f;

--- a/hal/avr32/i2c_avr32.cpp
+++ b/hal/avr32/i2c_avr32.cpp
@@ -99,8 +99,6 @@ bool I2c_avr32::init(void)
 bool I2c_avr32::probe(uint32_t address)
 {
     status_code_t status;
-    //using 7bits addressing instead of 8bits R/W formating
-    // status = twim_probe(twim_, address>>1);
     status = twim_probe(twim_, address);
     return status_code_to_bool(status);
 }
@@ -109,8 +107,6 @@ bool I2c_avr32::probe(uint32_t address)
 bool I2c_avr32::write(const uint8_t* buffer, uint32_t nbytes, uint32_t address)
 {
     status_code_t status;
-    // atmel's implementation of TWIM uses 7bits address (no R/W bit), so we shift the 8 bit address
-    // status = twim_write(twim_, buffer, nbytes, address>>1, config_.tenbit);
     status = twim_write(twim_, buffer, nbytes, address, config_.tenbit);
     return status_code_to_bool(status);
 }
@@ -119,8 +115,6 @@ bool I2c_avr32::write(const uint8_t* buffer, uint32_t nbytes, uint32_t address)
 bool I2c_avr32::read(uint8_t* buffer, uint32_t nbytes, uint32_t address)
 {
     status_code_t status;
-    // atmel's implementation of TWIM uses 7bits address (no R/W bit), so we shift the 8 bit address
-    // status = twim_read(twim_, buffer, nbytes, address>>1, config_.tenbit);
     status = twim_read(twim_, buffer, nbytes, address, config_.tenbit);
     return status_code_to_bool(status);
 }

--- a/hal/stm32/i2c_stm32.cpp
+++ b/hal/stm32/i2c_stm32.cpp
@@ -104,7 +104,8 @@ bool I2c_stm32::start(uint8_t address, bool direction_is_transmit, bool ack)
     //send write/read bit
     if (direction_is_transmit)
     {
-        I2C_DR(i2c_) = address & ~((uint16_t)0x0001);
+        //using 7bits addressing instead of 8bits R/W format
+        I2C_DR(i2c_) = address<<1 & ~((uint16_t)0x0001);
 
         //wait till finished
         timeout = i2c_timeout_;
@@ -118,7 +119,8 @@ bool I2c_stm32::start(uint8_t address, bool direction_is_transmit, bool ack)
     }
     else
     {
-        I2C_DR(i2c_) = address | ((uint16_t)0x0001);
+        //using 7bits addressing instead of 8bits R/W format
+        I2C_DR(i2c_) = address<<1 | ((uint16_t)0x0001);
 
         //wait till received
         timeout = i2c_timeout_;


### PR DESCRIPTION
I update the code to use 7bits addressing on both avr32 and stm32 platform.

This will solve a sonar problem on current avr32 since the @ was modified for 8bits R/W in that pull request #264 , and not reverted in #268 !

I tested that the ahrs and sonar are working fine on MegaFly rev4_1 boards.
So I think it should be merged asap, for the sonar fix

I also tested the sonar on the stm32 platform.