### PR TITLE
pb of fence while disabling imu calib in emulation

### DIFF
--- a/drivers/barometer.cpp
+++ b/drivers/barometer.cpp
@@ -49,8 +49,8 @@ extern "C"
 }
 
 Barometer::Barometer() :
-	has_been_read_(false),
-	has_been_calibrated_(false)
+    has_been_read_(false),
+    has_been_calibrated_(false)
 {
 
 }
@@ -86,17 +86,17 @@ const float& Barometer::temperature(void) const
 
 bool Barometer::has_been_calibrated() const
 {
-	return has_been_calibrated_;
+    return has_been_calibrated_;
 }
 
 void Barometer::calibrate_bias(float current_altitude_gf)
 {
-	if (has_been_read_)
-	{
-		altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
-    	altitude_gf_ = current_altitude_gf;
-    	has_been_calibrated_ = true;
-	}
+    if (has_been_read_)
+    {
+        altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
+        altitude_gf_ = current_altitude_gf;
+        has_been_calibrated_ = true;
+    }
 }
 
 

--- a/drivers/barometer.cpp
+++ b/drivers/barometer.cpp
@@ -48,6 +48,12 @@ extern "C"
 #include "util/maths.h"
 }
 
+Barometer::Barometer() :
+	has_been_read_(false),
+	has_been_calibrated_(false)
+{
+
+}
 
 const float& Barometer::last_update_us(void) const
 {
@@ -78,11 +84,19 @@ const float& Barometer::temperature(void) const
     return temperature_;
 }
 
+bool Barometer::has_been_calibrated() const
+{
+	return has_been_calibrated_;
+}
 
 void Barometer::calibrate_bias(float current_altitude_gf)
 {
-    altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
-    altitude_gf_ = current_altitude_gf;
+	if (has_been_read_)
+	{
+		altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
+    	altitude_gf_ = current_altitude_gf;
+    	has_been_calibrated_ = true;
+	}
 }
 
 

--- a/drivers/barometer.cpp
+++ b/drivers/barometer.cpp
@@ -49,7 +49,6 @@ extern "C"
 }
 
 Barometer::Barometer() :
-    has_been_read_(false),
     has_been_calibrated_(false)
 {
 
@@ -91,12 +90,9 @@ bool Barometer::has_been_calibrated() const
 
 void Barometer::calibrate_bias(float current_altitude_gf)
 {
-    if (has_been_read_)
-    {
-        altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
-        altitude_gf_ = current_altitude_gf;
-        has_been_calibrated_ = true;
-    }
+    altitude_bias_gf_ = altitude_filtered - current_altitude_gf;
+    altitude_gf_ = current_altitude_gf;
+    has_been_calibrated_ = true;
 }
 
 

--- a/drivers/barometer.hpp
+++ b/drivers/barometer.hpp
@@ -148,7 +148,6 @@ protected:
     float altitude_bias_gf_;    ///< Offset of the barometer sensor for matching GPS altitude value
     float speed_lf_;            ///< Vario altitude speed (ned frame)
     float last_update_us_;      ///< Time of the last update of the barometer
-    bool has_been_read_;        ///< Flag stating if there has been at least one read from the barometer
     bool has_been_calibrated_;  ///< Flag stating if the barometer has been calibrated
 };
 

--- a/drivers/barometer.hpp
+++ b/drivers/barometer.hpp
@@ -51,6 +51,8 @@
 class Barometer
 {
 public:
+    Barometer();
+
     /**
      * \brief   Initialise the sensor
      *
@@ -111,6 +113,12 @@ public:
      */
     const float& temperature(void) const;
 
+    /**
+     * \brief   Gets the flag stating if the barometer has been calibrated
+     *
+     * \return  has_been_read_
+     */
+    bool has_been_calibrated() const;
 
     /**
      * \brief   Correct altitude offset using current altitude
@@ -131,7 +139,6 @@ public:
      */
     static float altitude_from_pressure(float pressure, float altitude_bias = 0);
 
-
 protected:
 
     float pressure_;            ///< Measured pressure
@@ -141,7 +148,8 @@ protected:
     float altitude_bias_gf_;    ///< Offset of the barometer sensor for matching GPS altitude value
     float speed_lf_;            ///< Vario altitude speed (ned frame)
     float last_update_us_;      ///< Time of the last update of the barometer
-
+    bool has_been_read_;        ///< Flag stating if there has been at least one read from the barometer
+    bool has_been_calibrated_;  ///< Flag stating if the barometer has been calibrated
 };
 
 /**

--- a/drivers/bmp085.cpp
+++ b/drivers/bmp085.cpp
@@ -248,7 +248,6 @@ bool Bmp085::update(void)
             {
                 altitude_filtered = altitude_raw;
             }
-            has_been_read_ = true;
             
             // remove bias
             altitude_gf_ = altitude_filtered - altitude_bias_gf_;

--- a/drivers/bmp085.cpp
+++ b/drivers/bmp085.cpp
@@ -248,7 +248,8 @@ bool Bmp085::update(void)
             {
                 altitude_filtered = altitude_raw;
             }
-
+            has_been_read_ = true;
+            
             // remove bias
             altitude_gf_ = altitude_filtered - altitude_bias_gf_;
 

--- a/sensing/position_estimation.cpp
+++ b/sensing/position_estimation.cpp
@@ -157,10 +157,13 @@ void Position_estimation::position_correction()
     else
     {
         // Correct barometer bias
-        float current_altitude_gf = - local_position.pos[Z]
+        if (!barometer.has_been_calibrated())
+        {
+            float current_altitude_gf = - local_position.pos[Z]
                                     + local_position.origin.altitude;
-        barometer.calibrate_bias(current_altitude_gf);
-        init_barometer = true;
+            barometer.calibrate_bias(current_altitude_gf);
+            init_barometer = true;
+        }
     }
 
     if (init_gps_position)
@@ -411,18 +414,21 @@ void Position_estimation::reset_home_position()
     //}
 
     // Correct barometer bias
-    float current_altitude_gf = - local_position.pos[Z]
-                                + local_position.origin.altitude;
-    barometer.calibrate_bias(current_altitude_gf);
-    init_barometer = true;
+    if (!barometer.has_been_calibrated())
+    {
+        float current_altitude_gf = - local_position.pos[Z]
+                                    + local_position.origin.altitude;
+        barometer.calibrate_bias(current_altitude_gf);
+        init_barometer = true;
 
-    print_util_dbg_print("Offset of the barometer set to the GPS altitude, new altitude of:");
-    print_util_dbg_print_num(barometer.altitude_gf(), 10);
-    print_util_dbg_print(" ( ");
-    print_util_dbg_print_num(local_position.pos[2], 10);
-    print_util_dbg_print("  ");
-    print_util_dbg_print_num(local_position.origin.altitude, 10);
-    print_util_dbg_print(" )\r\n");
+        print_util_dbg_print("Offset of the barometer set to the GPS altitude, new altitude of:");
+        print_util_dbg_print_num(barometer.altitude_gf(), 10);
+        print_util_dbg_print(" ( ");
+        print_util_dbg_print_num(local_position.pos[2], 10);
+        print_util_dbg_print("  ");
+        print_util_dbg_print_num(local_position.origin.altitude, 10);
+        print_util_dbg_print(" )\r\n");
+    }
 
     // reset position estimator
     last_alt = 0;

--- a/sensing/position_estimation.cpp
+++ b/sensing/position_estimation.cpp
@@ -156,10 +156,14 @@ void Position_estimation::position_correction()
     }
     else
     {
-        // Correct barometer bias
-        float current_altitude_gf = - local_position.pos[Z]
-                                + local_position.origin.altitude;
-        barometer.calibrate_bias(current_altitude_gf);
+        // Wait for gps to initialized as we need an absolute altitude
+        if (init_gps_position)
+        {
+            // Correct barometer bias
+            float current_altitude_gf = - local_position.pos[Z]
+                                    + local_position.origin.altitude;
+            barometer.calibrate_bias(current_altitude_gf);
+        }
     }
 
     if (init_gps_position)
@@ -409,7 +413,8 @@ void Position_estimation::reset_home_position()
     //}
 
     // Correct barometer bias
-    if (!barometer.has_been_calibrated())
+    // Wait for gps to initialized as we need an absolute altitude
+    if (init_gps_position)
     {
         float current_altitude_gf = - local_position.pos[Z]
                                     + local_position.origin.altitude;

--- a/sensing/position_estimation.cpp
+++ b/sensing/position_estimation.cpp
@@ -139,7 +139,7 @@ void Position_estimation::position_correction()
     // uint32_t t_inter_baro;
     int32_t i;
 
-    if (init_barometer)
+    if (barometer.has_been_calibrated())
     {
         // altimeter correction
         if (time_last_barometer_msg < barometer.last_update_us())
@@ -157,13 +157,9 @@ void Position_estimation::position_correction()
     else
     {
         // Correct barometer bias
-        if (!barometer.has_been_calibrated())
-        {
-            float current_altitude_gf = - local_position.pos[Z]
-                                    + local_position.origin.altitude;
-            barometer.calibrate_bias(current_altitude_gf);
-            init_barometer = true;
-        }
+        float current_altitude_gf = - local_position.pos[Z]
+                                + local_position.origin.altitude;
+        barometer.calibrate_bias(current_altitude_gf);
     }
 
     if (init_gps_position)
@@ -329,7 +325,7 @@ bool Position_estimation::healthy() const
 
 bool Position_estimation::altitude_healthy() const
 {
-    return init_barometer;
+    return barometer.has_been_calibrated();
 }
 
 //------------------------------------------------------------------------------
@@ -347,7 +343,6 @@ Position_estimation::Position_estimation(State& state, Barometer& barometer, con
         time_last_gps_velned_msg(0),
         time_last_barometer_msg(0),
         init_gps_position(false),
-        init_barometer(false),
         last_alt(0),
         last_vel{0.0f,0.0f,0.0f},
         fence_set(config.fence_set),
@@ -419,7 +414,6 @@ void Position_estimation::reset_home_position()
         float current_altitude_gf = - local_position.pos[Z]
                                     + local_position.origin.altitude;
         barometer.calibrate_bias(current_altitude_gf);
-        init_barometer = true;
 
         print_util_dbg_print("Offset of the barometer set to the GPS altitude, new altitude of:");
         print_util_dbg_print_num(barometer.altitude_gf(), 10);

--- a/sensing/position_estimation.hpp
+++ b/sensing/position_estimation.hpp
@@ -196,7 +196,6 @@ private:
     uint32_t time_last_gps_velned_msg;      ///< Time at which we received the last GPS VELNED message in ms
     uint32_t time_last_barometer_msg;       ///< Time at which we received the last barometer message in ms
     bool init_gps_position;                 ///< Boolean flag ensuring that the GPS was initialized
-    bool init_barometer;                    ///< Boolean flag ensuring that the barometer was initialized
 
 
     float last_alt;                         ///< Value of the last altitude estimation

--- a/simulation/barometer_sim.cpp
+++ b/simulation/barometer_sim.cpp
@@ -85,7 +85,6 @@ bool Barometer_sim::update(void)
         // Get altitude
         float altitude_filtered_old = altitude_filtered;
         altitude_filtered = dynamic_model_.position_gf().altitude;
-        has_been_read_ = true;
         
         // Get variation of altitude
         speed_lf_       = - (altitude_filtered - altitude_filtered_old) / dt_s;

--- a/simulation/barometer_sim.cpp
+++ b/simulation/barometer_sim.cpp
@@ -85,7 +85,8 @@ bool Barometer_sim::update(void)
         // Get altitude
         float altitude_filtered_old = altitude_filtered;
         altitude_filtered = dynamic_model_.position_gf().altitude;
-
+        has_been_read_ = true;
+        
         // Get variation of altitude
         speed_lf_       = - (altitude_filtered - altitude_filtered_old) / dt_s;
         altitude_gf_    = altitude_filtered - altitude_bias_gf_;

--- a/util/maths.h
+++ b/util/maths.h
@@ -102,19 +102,27 @@ float static inline maths_rad_to_deg(float i)
 
 
 /**
- * \brief           For any given angle, computes an equivalent angle between -2pi and 2pi
+ * \brief           For any given angle, computes an equivalent angle between -pi and pi
  *
  * \param   angle   Input angle
  *
  * \return          Output angle
  */
-float static inline maths_calc_smaller_angle(float angle)
-{
-    float out = angle;
-    while (out < -PI) out += 2.0f * PI;
-    while (out >= PI) out -= 2.0f * PI;
-    return out;
-}
+ float static inline maths_calc_smaller_angle(float angle)
+ {
+     float out;
+
+     if (angle > 0.0f)
+     {
+         out = fmod(angle + PI, 2.0f * PI) - PI;
+     }
+     else
+     {
+         out = fmod(angle - PI, 2.0f * PI) + PI;
+     }
+
+     return out;
+ }
 
 
 /**


### PR DESCRIPTION
This fixes #287 by creating two flags in the barometer class. One that is false until a measurement has been read and one that is false until it has been calibrated. A getter function returns the has_been_calibrated_ boolean so we can know if we should set position_estimation::barometer_init appropriately.

This has been tested in emulation.