### PR TITLE
Fix datalogging of a single variable

### DIFF
--- a/communication/data_logging.cpp
+++ b/communication/data_logging.cpp
@@ -75,20 +75,17 @@ void Data_logging::add_header_name(void)
         data_logging_entry_t* param = &data_log_[i];
 
         init &= console_.write(reinterpret_cast<uint8_t*>(param->param_name), strlen(param->param_name));
+        write_separator(i);
 
         if (!init)
         {
-            break;
             if (debug_)
             {
                 print_util_dbg_print("Error appending header!\r\n");
             }
         }
-        else
-        {
-            write_separator(i);
-        }
     }
+
     file_init_ = init;
 }
 
@@ -97,15 +94,17 @@ void Data_logging::write_separator(uint16_t param_num)
 {
     bool success = true;
 
-    // Writes a tab character or a end of line character to the file depending on the parameter current number
     if (param_num == (data_logging_count_ - 1))
     {
+        // Last variable -> end of line
         success &= console_.write("\n");
     }
     else
     {
+        // Not last variable -> separator
         success &= console_.write(",");
     }
+
     if (!success)
     {
         if (debug_)
@@ -181,9 +180,10 @@ void Data_logging::log_parameters(void)
                 success &= console_.write(*((double*)param->param), param->precision);
                 write_separator(i);
                 break;
+
             default:
                 success &= false;
-                print_util_dbg_print("Data type not supported!\r\n");
+                write_separator(i);
                 break;
         }
 
@@ -193,7 +193,6 @@ void Data_logging::log_parameters(void)
             {
                 print_util_dbg_print("Error appending parameter! Error:");
             }
-            break;
         }
     }
 }
@@ -256,11 +255,11 @@ bool Data_logging::filename_append_extension(char* output, char* filename, uint3
         return is_success;
     }
 
-    // Add ".txt"
+    // Add ".csv"
     output[i] = '.';
-    output[i + 1] = 't';
-    output[i + 2] = 'x';
-    output[i + 3] = 't';
+    output[i + 1] = 'c';
+    output[i + 2] = 's';
+    output[i + 3] = 'v';
 
     // Add null character
     output[i + 4] = '\0';

--- a/communication/data_logging.cpp
+++ b/communication/data_logging.cpp
@@ -68,8 +68,7 @@ void Data_logging::add_header_name(void)
 
     uint16_t i;
 
-    init &= console_.write("time");
-    put_r_or_n(0);
+    init &= console_.write("time,");
 
     for (i = 0; i < data_logging_count_; i++)
     {
@@ -87,14 +86,14 @@ void Data_logging::add_header_name(void)
         }
         else
         {
-            put_r_or_n(i);
+            write_separator(i);
         }
     }
     file_init_ = init;
 }
 
 
-void Data_logging::put_r_or_n(uint16_t param_num)
+void Data_logging::write_separator(uint16_t param_num)
 {
     bool success = true;
 
@@ -105,7 +104,7 @@ void Data_logging::put_r_or_n(uint16_t param_num)
     }
     else
     {
-        success &= console_.write("\t");
+        success &= console_.write(",");
     }
     if (!success)
     {
@@ -125,7 +124,7 @@ void Data_logging::log_parameters(void)
     // First parameter is always time
     uint32_t time_ms = time_keeper_get_ms();
     success &=  console_.write(time_ms);
-    put_r_or_n(0);
+    success &=  console_.write(",");
 
     for (i = 0; i < data_logging_count_; i++)
     {
@@ -135,52 +134,52 @@ void Data_logging::log_parameters(void)
         {
             case MAV_PARAM_TYPE_UINT8:
                 success &= console_.write(*((uint8_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_INT8:
                 success &= console_.write(*((int8_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_UINT16:
                 success &= console_.write(*((uint16_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_INT16:
                 success &= console_.write(*((int16_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_UINT32:
                 success &= console_.write(*((uint32_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_INT32:
                 success &= console_.write(*((int32_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_UINT64:
                 success &= console_.write(*((uint64_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_INT64:
                 success &= console_.write(*((int64_t*)param->param));
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_REAL32:
                 success &= console_.write(*(float*)param->param, param->precision);
-                put_r_or_n(i);
+                write_separator(i);
                 break;
 
             case MAV_PARAM_TYPE_REAL64:
                 success &= console_.write(*((double*)param->param), param->precision);
-                put_r_or_n(i);
+                write_separator(i);
                 break;
             default:
                 success &= false;

--- a/communication/data_logging.hpp
+++ b/communication/data_logging.hpp
@@ -175,12 +175,12 @@ private:
 
 
     /**
-     * \brief   Function to put a \r or a \n after the data logging parameter value (\r between them and \n and the end)
+     * \brief   Function to put a "," or a "\n" after the data logging parameter value ("," between them and "\n" and the end)
      *
      * \param   data_logging            The pointer to the data logging structure
      * \param   param_num               The index of the data logging parameter
      */
-    void put_r_or_n(uint16_t param_num);
+    void write_separator(uint16_t param_num);
 
 
     /**

--- a/sample_projects/LEQuad/lequad.cpp
+++ b/sample_projects/LEQuad/lequad.cpp
@@ -131,8 +131,8 @@ void LEQuad::loop(void)
     }
 
     // Create log files
-    data_logging_continuous.create_new_log_file("Log_file", true, mavlink_communication.sysid());
-    data_logging_stat.create_new_log_file("Log_Stat", false, mavlink_communication.sysid());
+    data_logging_continuous.create_new_log_file("log", true, mavlink_communication.sysid());
+    data_logging_stat.create_new_log_file("stat", false, mavlink_communication.sysid());
 
     // Init mav state
     state.mav_state_ = MAV_STATE_STANDBY;  // TODO check if this is necessary


### PR DESCRIPTION
Fix #298 

- fix datalogging of a single variable
- use csv extension and comma separator for easier import
- do not stop logging if one variable was not successfully written (ie. keep number of columns even if data is missing)
- shorter file name
