### PR TITLE
Waypoint handler rewrite

### DIFF
--- a/boards/sparky_v2.cpp
+++ b/boards/sparky_v2.cpp
@@ -96,8 +96,13 @@ Sparky_v2::Sparky_v2(sparky_v2_conf_t config):
     servo_6_(pwm_6_, config.servo_config[6]),
     servo_7_(pwm_7_, config.servo_config[7]),
     spi_1_(config.spi_config[0]),
-    spi_3_(config.spi_config[2]),
-    state_display_sparky_v2_(led_stat_, led_err_)
+    spi_3_(config.spi_config[1]),
+    nss_1_gpio_(config.nss_gpio_config[0]),
+    nss_2_gpio_(config.nss_gpio_config[1]),
+    nss_3_gpio_(config.nss_gpio_config[2]),
+    state_display_sparky_v2_(led_stat_, led_err_),
+    mpu_9250_(spi_1_, nss_1_gpio_),
+    imu_(mpu_9250_, mpu_9250_, mpu_9250_, config.imu_config)
 {}
 
 
@@ -267,6 +272,15 @@ bool Sparky_v2::init(void)
     ret = spi_1_.init();
     ret = spi_3_.init();
     init_success &= ret;
+
+    // -------------------------------------------------------------------------
+    // Init IMU
+    // -------------------------------------------------------------------------
+    ret = mpu_9250_.init();
+    init_success &= ret;
+
+    time_keeper_delay_ms(50);
+
 
     return init_success;
 }

--- a/drivers/mpu_9250.cpp
+++ b/drivers/mpu_9250.cpp
@@ -1,0 +1,526 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file mpu_9250.cpp
+ *
+ * \author MAV'RIC Team
+ * \author Jean-François Burnier
+ *
+ * \brief This file is the driver for the integrated 3axis gyroscope,
+ *        accelerometer and magnetometer: MPU 9250
+ *
+ ******************************************************************************/
+#include "drivers/mpu_9250.hpp"
+#include "hal/common/time_keeper.hpp"
+#include "hal/common/spi.hpp"
+
+//------------------------------------------------------------------------------
+// PUBLIC FUNCTIONS IMPLEMENTATION
+//------------------------------------------------------------------------------
+Mpu_9250::Mpu_9250(Spi& spi, Gpio& nss_gpio, const conf_t config):
+    spi_(spi),
+    nss_(nss_gpio),
+    acc_data_(std::array<float,3>{{0.0f, 0.0f, 0.0f}}),
+    gyro_data_(std::array<float,3>{{0.0f, 0.0f, 0.0f}}),
+    mag_data_(std::array<float,3>{{0.0f, 0.0f, 0.0f}}),
+    temperature_(0.0f),
+    last_update_us_(0.0f),
+    config_(config)
+{
+    switch (config.acc_range)
+    {
+        case ACC_2G:
+            acc_scale_ = 16384;
+            break;
+
+        case ACC_4G:
+            acc_scale_ = 8192;
+            break;
+
+        case ACC_8G:
+            acc_scale_ = 4096;
+            break;
+
+        case ACC_16G:
+            acc_scale_ = 2048;
+            break;
+    }
+
+    switch (config.gyro_range)
+    {
+        case GYRO_250_DEG:
+            gyro_scale_ = 131;
+            break;
+
+        case GYRO_500_DEG:
+            gyro_scale_ = 65.5;
+            break;
+
+        case GYRO_1000_DEG:
+            gyro_scale_ = 32.8;
+            break;
+
+        case GYRO_2000_DEG:
+            gyro_scale_ = 16.4;
+            break;
+    }
+
+    // converting from dps to rps
+    gyro_scale_ *= 180.0f/3.14159f;
+}
+
+bool Mpu_9250::init(void)
+{
+    bool success = true;
+
+    // Initializing Slave Select GPIO
+    success &= nss_.init();
+
+    // Reset accelerometer and gyroscope
+    success &= mpu_reset();
+
+    // Read WhoAmI for Acc and Gyr
+    uint8_t whoami_answer   = 0;
+    success &= read_reg(WHOAMI_REG, &whoami_answer);
+    success &= whoami_answer == WHOAMI_ID ? true : false;
+
+    // Automatic best available clock selection
+    uint8_t power_management_cmd = PWRMGMT_PLL_X_CLK;
+    success &= write_reg(PWR_MGMT_REG, &power_management_cmd);
+
+    // Enable communication with Mag
+    uint8_t mag_communication_en = (uint8_t)(USERCTL_I2C_MST_EN |
+                                             USERCTL_DIS_I2C);
+    success &= write_reg(USER_CTRL_REG, &mag_communication_en);
+
+    // Reset magnetometer
+    success &= mag_reset();
+
+    // Read WhoAmI for Mag
+    success &= mag_read_reg(AK8963_WHOAMI_REG, &whoami_answer);
+    success &= whoami_answer == AK8963_WHOAMI_ID ? true : false;
+
+    if (!success)
+    {
+        // Returning if device not responding
+        return success;
+    }
+
+    // Configuring Magnetometer, has to be done before configuring
+    // acc and gyro in order to work
+    success = set_mag_mode();
+
+    // Use slv0 to access mag raw datas (x,y,z and status 2 register)
+    // burst read used
+    uint8_t first_reg       = AK8963_HXL;
+    uint8_t address         = (uint8_t)(AK8963_ADDR | READ_FLAG);
+    uint8_t slv0_ctrl_reg   = (uint8_t)(I2CSLV_EN | 7);
+
+    success &= write_reg(SLV0_REG_REG , &first_reg);
+    success &= write_reg(SLV0_ADDR_REG, &address);
+    success &= write_reg(SLV0_CTRL_REG, &slv0_ctrl_reg);
+
+    // Configuring Accelerometer and Gyroscope
+    success &= set_acc_lpf();
+    success &= set_gyro_lpf();
+    success &= set_mpu_sample_rate();
+    success &= set_acc_range();
+    success &= set_gyro_range();
+
+    return success;
+}
+
+
+bool Mpu_9250::update_acc(void)
+{
+    bool success = true;
+
+    // Read raw data from accelerometer (big endian)
+    uint8_t acc_data_raw[6] = {0};
+    success &= read_reg(ACCEL_X_OUT_MSB, acc_data_raw, 6);
+
+    acc_data_[0] = (float)((int16_t)(acc_data_raw[0] << 8 | acc_data_raw[1]));
+    acc_data_[1] = (float)((int16_t)(acc_data_raw[2] << 8 | acc_data_raw[3]));
+    acc_data_[2] = (float)((int16_t)(acc_data_raw[4] << 8 | acc_data_raw[5]));
+
+    acc_data_[0] /= acc_scale_;
+    acc_data_[1] /= acc_scale_;
+    acc_data_[2] /= acc_scale_;
+
+    last_update_us_ = time_keeper_get_us();
+
+    return success;
+}
+
+
+bool Mpu_9250::update_gyr(void)
+{
+    bool success = true;
+
+    // Read raw data from gyroscope (big endian)
+    uint8_t gyro_data_raw[6] = {0};
+    success &= read_reg(GYRO_X_OUT_MSB, gyro_data_raw, 6);
+
+    gyro_data_[0] = (float)((int16_t)(gyro_data_raw[0] << 8 | gyro_data_raw[1]));
+    gyro_data_[1] = (float)((int16_t)(gyro_data_raw[2] << 8 | gyro_data_raw[3]));
+    gyro_data_[2] = (float)((int16_t)(gyro_data_raw[4] << 8 | gyro_data_raw[5]));
+
+    // Gyroscope is sending dps, scaling it to get rps
+    gyro_data_[0] /= gyro_scale_;
+    gyro_data_[1] /= gyro_scale_;
+    gyro_data_[2] /= gyro_scale_;
+    
+    last_update_us_ = time_keeper_get_us();
+
+    return success;
+}
+
+bool Mpu_9250::update_mag(void)
+{
+    bool success = true;
+
+    // Read raw data from magnetometer (little endian)
+    uint8_t mag_data_raw[6] = {0};
+    success &= read_reg(EXT_SENS_DATA_00, mag_data_raw, 6);
+    
+    mag_data_[0] = (float)((int16_t)(mag_data_raw[1] << 8 | mag_data_raw[0]));
+    mag_data_[1] = (float)((int16_t)(mag_data_raw[3] << 8 | mag_data_raw[2]));
+    mag_data_[2] = (float)((int16_t)(mag_data_raw[5] << 8 | mag_data_raw[4]));
+    
+    last_update_us_ = time_keeper_get_us();
+
+    return success;
+}
+
+
+const float& Mpu_9250::last_update_us(void) const
+{
+    return last_update_us_;
+}
+
+
+const std::array<float, 3>& Mpu_9250::gyro(void) const
+{
+    return gyro_data_;
+}
+
+
+const float& Mpu_9250::gyro_X(void) const
+{
+    return gyro_data_[0];
+}
+
+
+const float& Mpu_9250::gyro_Y(void) const
+{
+    return gyro_data_[1];
+}
+
+
+const float& Mpu_9250::gyro_Z(void) const
+{
+    return gyro_data_[2];
+}
+
+
+const std::array<float, 3>& Mpu_9250::acc(void) const
+{
+    return acc_data_;
+}
+
+
+const float& Mpu_9250::acc_X(void) const
+{
+    return acc_data_[0];
+}
+
+
+const float& Mpu_9250::acc_Y(void) const
+{
+    return acc_data_[1];
+}
+
+
+const float& Mpu_9250::acc_Z(void) const
+{
+    return acc_data_[2];
+}
+
+const std::array<float, 3>& Mpu_9250::mag(void) const
+{
+    return mag_data_;
+}
+
+
+const float& Mpu_9250::mag_X(void) const
+{
+    return mag_data_[0];
+}
+
+
+const float& Mpu_9250::mag_Y(void) const
+{
+    return mag_data_[1];
+}
+
+
+const float& Mpu_9250::mag_Z(void) const
+{
+    return mag_data_[2];
+}
+
+
+const float& Mpu_9250::temperature(void) const
+{
+    return temperature_;
+}
+
+bool Mpu_9250::mag_reset(void)
+{
+    bool ret = true;
+
+    // Write reset
+     uint8_t reset_command = AK8963_CNTL2_SRST;
+     ret &= mag_write_reg(AK8963_CNTL2_REG, &reset_command);
+
+    // Let the sensor reset
+    time_keeper_delay_ms(50);
+
+    return ret;
+}
+
+bool Mpu_9250::mpu_reset(void)
+{
+    bool ret = true;
+
+    uint8_t reset_command = PWRMGMT_IMU_RST;
+
+    // Write reset
+    ret &= write_reg(PWR_MGMT_REG, &reset_command);
+
+    // Let the sensor reset
+    time_keeper_delay_ms(50);
+
+    return ret;
+}
+
+bool Mpu_9250::mag_read_reg(uint8_t reg, uint8_t* in_data)
+{
+    bool     ret     = true;
+    uint8_t  status  = 0;
+    uint32_t timeout = 0;
+
+    // Use of I2C SLV4 to access AK8963 (mag) registers
+    uint8_t reg_to_read     = reg;
+    uint8_t address         = (uint8_t)(AK8963_ADDR | READ_FLAG);
+    uint8_t i2c_slave_en    = I2CSLV_EN;
+
+    ret &= write_reg(SLV4_REG_REG , &reg_to_read);
+    ret &= write_reg(SLV4_ADDR_REG, &address);
+    ret &= write_reg(SLV4_CTRL_REG, &i2c_slave_en);
+
+    // Wait for I2C transaction done
+    do {
+        if (timeout++ > 50)
+        {
+            // Returns to prevent endless loop
+            return false;
+        }
+
+        // Check if transaction done
+        read_reg(I2C_MST_STATUS_REG, &status);
+    } while (!(status & I2C_MST_SLV4_DONE));
+
+    // Read data
+    ret &= read_reg(SLV4_DI_REG, in_data); // TODO: allow multiple data reading
+
+    return ret;
+}
+
+bool Mpu_9250::mag_write_reg(uint8_t reg, uint8_t* out_data)
+{
+    bool ret = true;
+    uint8_t status = 0;
+    uint32_t timeout = 0;
+
+    // Use of I2C SLV4 to access AK8963 (mag) registers
+    uint8_t reg_to_write    = reg;
+    uint8_t address         = (uint8_t)(AK8963_ADDR & WRITE_FLAG);
+    uint8_t data_to_write   = out_data[0];                       // TODO: allow multiple data writing
+    uint8_t i2c_slave_en    = I2CSLV_EN;
+
+    ret &= write_reg(SLV4_REG_REG , &reg_to_write);
+    ret &= write_reg(SLV4_ADDR_REG, &address);
+    ret &= write_reg(SLV4_DO_REG  , &data_to_write);
+    ret &= write_reg(SLV4_CTRL_REG, &i2c_slave_en);
+
+    // Wait for I2C transaction done
+    do {
+        if (timeout++ > 50)
+        {
+            // Return to prevent endless loop
+            return false;
+        }
+
+        // Check if transaction done
+        read_reg(I2C_MST_STATUS_REG, &status);
+    } while (!(status & I2C_MST_SLV4_DONE));
+
+    if (status & I2C_MST_SLV4_NACK)
+    {
+        return false;
+    }
+
+    return ret;
+}
+
+bool Mpu_9250::read_reg(uint8_t reg, uint8_t* in_data, uint32_t nbytes)
+{
+    bool ret = true;
+    reg |= READ_FLAG;
+
+    select_slave();
+
+    // Write register
+    ret &= spi_.transfer(&reg, NULL, 1);
+
+    // Read data from register
+    ret &= spi_.transfer(NULL, in_data, nbytes);
+
+    unselect_slave();
+
+    return ret;
+}
+
+bool Mpu_9250::write_reg(uint8_t reg, uint8_t* out_data, uint32_t nbytes)
+{
+    bool ret = true;
+    reg &= WRITE_FLAG;
+
+    select_slave();
+
+    // Write register
+    ret &= spi_.transfer(&reg, NULL, 1);
+
+    // Write data to register
+    ret &= spi_.transfer(out_data, NULL, nbytes);
+
+    unselect_slave();
+
+
+    return ret;
+}
+
+//------------------------------------------------------------------------------
+// PRIVATE FUNCTIONS IMPLEMENTATION
+//------------------------------------------------------------------------------
+bool Mpu_9250::set_acc_lpf(void)
+{
+    uint8_t accelerometer_lpf = config_.acc_filter;
+    return write_reg(ACCEL_CFG2_REG, &accelerometer_lpf);
+}
+
+bool Mpu_9250::set_gyro_lpf(void)
+{
+    uint8_t gyroscope_lpf = config_.gyro_filter;
+    return write_reg(DLPF_CFG_REG, &gyroscope_lpf);
+}
+
+bool Mpu_9250::set_mag_mode(void)
+{
+    uint8_t mode = (uint8_t)(AK8963_CNTL1_16BITS | AK8963_CNTL1_CONT_100HZ);
+    return mag_write_reg(AK8963_CNTL1_REG, &mode);
+}
+
+bool Mpu_9250::set_mpu_sample_rate(void)
+{
+    uint16_t samplerate_hz = config_.default_sample_rate;
+
+    // mpu9250 ODR divider is unable to run from 8kHz clock like mpu60x0 :(
+    // check if someone want to use 250Hz DLPF and don't want 8kHz sampling
+    // and politely refuse him
+    if ((config_.gyro_filter == GYRO_LOWPASS_250_HZ) && (samplerate_hz != 8000))
+    {
+        return false;
+    }
+
+    uint16_t filter_frequency   = 1000; // Hz
+
+    // limit samplerate to filter frequency
+    if (samplerate_hz > filter_frequency)
+    {
+        samplerate_hz = filter_frequency;
+    }
+
+    // calculate divisor, round to nearest integeter
+    int32_t divisor = (int32_t)(((float)filter_frequency / samplerate_hz) + 0.5f) - 1;
+
+    // limit resulting divisor to register value range
+    if (divisor < 0)
+    {
+        divisor = 0; // samplerate = 1 kHz
+    }
+
+    if (divisor > 0xff)
+    {
+        divisor = 0xff; // samplerate = 3.91 Hz
+    }
+
+    // Write sample rate divisor in register (effective divisor is sample
+    // rate divisor +1)
+    uint8_t sample_rate_div = (uint8_t)divisor;
+    return write_reg(SMPLRT_DIV_REG, &sample_rate_div);
+}
+
+bool Mpu_9250::set_acc_range(void)
+{
+    uint8_t accelerometer_range = config_.acc_range;
+    return write_reg(ACCEL_CFG_REG, &accelerometer_range);
+}
+
+bool Mpu_9250::set_gyro_range(void)
+{
+    uint8_t gyroscope_range = config_.gyro_range;
+    return write_reg(GYRO_CFG_REG, &gyroscope_range);
+}
+
+void Mpu_9250::select_slave(void)
+{
+    nss_.set_low();
+    return;
+}
+
+void Mpu_9250::unselect_slave(void)
+{
+    nss_.set_high();
+    return;
+}

--- a/drivers/mpu_9250.hpp
+++ b/drivers/mpu_9250.hpp
@@ -1,0 +1,595 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file mpu_9250.hpp
+ *
+ * \author MAV'RIC Team
+ * \author Jean-François Burnier
+ *
+ * \brief This file is the driver for the integrated 3axis gyroscope,
+ *        accelerometer and magnetometer: MPU 9250
+ *
+ ******************************************************************************/
+
+
+#ifndef MPU_9250_HPP_
+#define MPU_9250_HPP_
+
+#include <cstdint>
+#include <array>
+
+#include "drivers/accelerometer.hpp"
+#include "drivers/gyroscope.hpp"
+#include "drivers/magnetometer.hpp"
+
+#include "hal/common/gpio.hpp"
+#include "hal/common/spi.hpp"
+
+/**
+ * \brief       Intermediate interface class for the accelero inside MPU 9250
+ *
+ * \details     Inherits only accelerometer
+ */
+class Mpu_9250_acc: public Accelerometer
+{
+public:
+    virtual bool update_acc(void) = 0;
+
+    bool update(void)
+    {
+        return update_acc();
+    }
+};
+
+
+/**
+ * \brief       Intermediate interface class for the gyro inside MPU 9250
+ *
+ * \details     Inherits only gyroscope
+ */
+class Mpu_9250_gyr: public Gyroscope
+{
+public:
+    virtual bool update_gyr(void) = 0;
+
+    bool update(void)
+    {
+        return update_gyr();
+    }
+};
+
+/**
+ * \brief       Intermediate interface class for the mag inside MPU 9250
+ *
+ * \details     Inherits only magnetometer
+ */
+ class Mpu_9250_mag: public Magnetometer
+{
+public:
+    virtual bool update_mag(void) = 0;
+
+    bool update(void)
+    {
+        return update_mag();
+    }
+};
+
+
+/**
+ * \brief       Driver for sensor MPU 9250
+ *
+ * \details     This sensor is at the same time a accelerometer and a gyroscope and a magnetometer
+ *              The inherited method Accelerometer::update is implemented as Mpu9250::update_acc
+ *              The inherited method Gyroscope::update is implemented as Mpu9250::update_gyr
+ *              The inherited method Magnetometer::update is implemented as Mpu9250::update_mag
+ */
+class Mpu_9250: public Mpu_9250_acc, public Mpu_9250_gyr, public Mpu_9250_mag
+{
+public:
+    /*
+     * \brief   Enum for defining lowpass filter frequency
+     *          for accelerometer
+     */
+    typedef enum
+    {
+        ACC_LOWPASS_460_HZ = 0x00,
+        ACC_LOWPASS_184_HZ = 0x01,
+        ACC_LOWPASS_92_HZ  = 0x02,
+        ACC_LOWPASS_41_HZ  = 0x03,
+        ACC_LOWPASS_20_HZ  = 0x04,
+        ACC_LOWPASS_10_HZ  = 0x05,
+        ACC_LOWPASS_5_HZ   = 0x06,
+    } acc_filter_t;
+
+    /*
+     * \brief   Enum for defining range for accelerometer
+     */
+    typedef enum
+    {
+        ACC_2G    = 0x00,
+        ACC_4G    = 0x08,
+        ACC_8G    = 0x10,
+        ACC_16G   = 0x18,
+    } acc_range_t ;
+
+    /*
+     * \brief   Enum for defining lowpass filter frequency
+     *          for gyroscope
+     */
+    typedef enum
+    {
+        GYRO_LOWPASS_250_HZ = 0x00,
+        GYRO_LOWPASS_184_HZ = 0x01,
+        GYRO_LOWPASS_92_HZ  = 0x02,
+        GYRO_LOWPASS_41_HZ  = 0x03,
+        GYRO_LOWPASS_20_HZ  = 0x04,
+        GYRO_LOWPASS_10_HZ  = 0x05,
+        GYRO_LOWPASS_5_HZ   = 0x06,
+    } gyro_filter_t;
+
+    /*
+     * \brief   Enum for defining range for gyroscope
+     */
+    typedef enum
+    {
+        GYRO_250_DEG  = 0x00,
+        GYRO_500_DEG  = 0x08,
+        GYRO_1000_DEG = 0x10,
+        GYRO_2000_DEG = 0x18,
+    } gyro_range_t ;
+
+    /**
+     * \brief   Configuration structure for mpu 9250
+     */
+    typedef struct
+    {
+        acc_filter_t       acc_filter;         ///< Accelerometer lp filter cut off freq
+        acc_range_t        acc_range;          ///< Accelerometer range
+        gyro_filter_t      gyro_filter;        ///< Gyroscope lp filter cut off freq
+        gyro_range_t       gyro_range;         ///< Gyroscope range
+        uint16_t           default_sample_rate;///< Default sample rate in Herz
+
+    } conf_t;
+
+    /**
+     * \brief   Default configuration for mpu 9250
+     *
+     * \return  Conf structure
+     */
+    static inline conf_t mpu_9250_default_config()
+    {
+        conf_t conf                 = {};
+
+        conf.acc_filter             = ACC_LOWPASS_184_HZ;
+        conf.acc_range              = ACC_2G;
+        conf.gyro_filter            = GYRO_LOWPASS_184_HZ;
+        conf.gyro_range             = GYRO_500_DEG;
+        conf.default_sample_rate    = 500; // in Hz
+
+        return conf;
+    };
+
+    /**
+     * \brief   Constructor
+     *
+     * \param   spi         Reference to SPI device
+     * \param   nss_gpio    Reference to Slave Select GPIO
+     * \param   config      Device configuration
+     */
+    Mpu_9250(Spi& spi, Gpio& nss_gpio, const conf_t config = mpu_9250_default_config());
+
+
+    /**
+     * \brief   Initialise the sensor
+     * \details Sends configuration via SPI, the SPI peripheral must be
+     *          activated before this method is called
+     *
+     * \return  true    Success
+     * \return  false   Failed
+     */
+    bool init(void);
+
+
+    /**
+     * \brief   Main update function
+     * \details Get new data from the sensor
+     *
+     * \return  true    Success
+     * \return  false   Failed
+     */
+    bool update_acc(void);
+    bool update_gyr(void);
+    bool update_mag(void);
+
+
+    /**
+     * \brief   Get last update time in microseconds
+     *
+     * \return  Update time
+     */
+    const float& last_update_us(void) const;
+
+
+    /**
+     * \brief   Get X, Y and Z components of angular velocity
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const std::array<float, 3>& gyro(void) const;
+
+
+
+    /**
+     * \brief   Get X component of angular velocity
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const float& gyro_X(void) const;
+
+
+    /**
+     * \brief   Get Y component of angular velocity
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const float& gyro_Y(void) const;
+
+
+    /**
+     * \brief   Get Z component of angular velocity
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const float& gyro_Z(void) const;
+
+
+    /**
+     * \brief   Get X, Y and Z components of acceleration
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const std::array<float, 3>& acc(void) const;
+
+
+    /**
+     * \brief   Get X component of acceleration
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const float& acc_X(void) const;
+
+
+    /**
+     * \brief   Get Y component of acceleration
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const float& acc_Y(void) const;
+
+
+    /**
+     * \brief   Get Z component of acceleration
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, are scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal and axis rotations
+     *
+     * \return  Value
+     */
+    const float& acc_Z(void) const;
+
+    /**
+     * \brief   Get X, Y and Z components of magnetic field
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, not scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal, scaling and axis rotations
+     *
+     * \return  Value
+     */
+    const std::array<float, 3>& mag(void) const;
+
+
+    /**
+     * \brief   Get X component of magnetic field
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, not scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal, scaling and axis rotations
+     *
+     * \return  Value
+     */
+    const float& mag_X(void) const;
+
+
+    /**
+     * \brief   Get Y component of magnetic field
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, not scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal, scaling and axis rotations
+     *
+     * \return  Value
+     */
+    const float& mag_Y(void) const;
+
+
+    /**
+     * \brief   Get Z component of magnetic field
+     *
+     * \detail  This is raw data, so X, Y and Z components are biased, not scaled,
+     *          and given in the sensor frame (not in the UAV frame).
+     *          Use an Imu object to handle bias removal, scaling and axis rotations
+     *
+     * \return  Value
+     */
+    const float& mag_Z(void) const;
+
+    /**
+     * \brief   Get sensor temperature
+     *
+     * \return  Value
+     */
+    const float& temperature(void) const;
+
+    /**
+     * \brief   Reset acc and gyro
+     *
+     * \return  success
+     */
+    bool mpu_reset(void);
+
+    /**
+     * \brief   Reset magnetometer
+     *
+     * \return  success
+     */
+    bool mag_reset(void);
+
+    /**
+     * \brief   Read register from magnetometer
+     *
+     * \param   reg         Register to read from
+     * \param   in_data     Incoming data
+     *
+     * \return  success
+     */
+    bool mag_read_reg(uint8_t reg, uint8_t* in_data);
+
+    /**
+     * \brief   Write values in register of ak8963
+     *
+     * \param   reg         Register to write to
+     * \param   out_data    Outgoing data
+     *
+     * \return  success
+     */
+    bool mag_write_reg(uint8_t reg, uint8_t* out_data);
+
+    /**
+     * \brief   Write register of mpu 9250
+     *
+     * \detail  Write data to the specified register,
+     *          burst write possible by specifying the
+     *          number of bytes to write
+     *
+     * \param   reg         Register to write to
+     * \param   out_data    Outgoing data
+     * \param   nbytes      Number of bytes to write
+     *
+     * \return  success
+     */
+    bool write_reg(uint8_t reg, uint8_t* out_data, uint32_t nbytes = 1);
+
+    /**
+     * \brief   Read register of mpu 9250
+
+     * \detail  Read data at the specified register,
+     *          burst read possible by specifying the
+     *          number of bytes to read
+     *
+     * \param   reg         Register to read from
+     * \param   in_data     Incoming data
+     * \param   nbytes      Number of bytes to read
+     *
+     * \return  success
+     */
+    bool read_reg(uint8_t reg, uint8_t* in_data, uint32_t nbytes = 1);
+
+    // AK8963 register addresses
+    static const uint8_t AK8963_WHOAMI_REG     = 0x00;
+    static const uint8_t AK8963_ST1_REG        = 0x02;
+    static const uint8_t AK8963_HXL            = 0x03;
+    static const uint8_t AK8963_ST2_REG        = 0x09;
+
+    // AK8963 register bits
+    static const uint8_t AK8963_CNTL1_CONT_8HZ     = 0x02;
+    static const uint8_t AK8963_CNTL1_CONT_100HZ   = 0x06;
+    static const uint8_t AK8963_CNTL1_16BITS       = 0x10;
+    static const uint8_t AK8963_CNTL1_REG          = 0x0A;
+    static const uint8_t AK8963_CNTL2_REG          = 0x0B;
+    static const uint8_t AK8963_CNTL2_SRST         = 0x01;
+    static const uint8_t AK8963_WHOAMI_ID          = 0x48;
+
+    // MPU9250 register adresses
+    static const uint8_t AK8963_ADDR           = 0x0C;
+    static const uint8_t SMPLRT_DIV_REG        = 0x19;
+    static const uint8_t DLPF_CFG_REG          = 0x1A;
+    static const uint8_t GYRO_CFG_REG          = 0x1B;
+    static const uint8_t ACCEL_CFG_REG         = 0x1C;
+    static const uint8_t ACCEL_CFG2_REG        = 0x1D;
+    static const uint8_t SLV0_ADDR_REG         = 0x25;
+    static const uint8_t SLV0_REG_REG          = 0x26;
+    static const uint8_t SLV0_CTRL_REG         = 0x27;
+    static const uint8_t SLV4_ADDR_REG         = 0x31;
+    static const uint8_t SLV4_REG_REG          = 0x32;
+    static const uint8_t SLV4_DO_REG           = 0x33;
+    static const uint8_t SLV4_CTRL_REG         = 0x34;
+    static const uint8_t SLV4_DI_REG           = 0x35;
+    static const uint8_t I2C_MST_STATUS_REG    = 0x36;
+    static const uint8_t ACCEL_X_OUT_MSB       = 0x3B;
+    static const uint8_t ACCEL_X_OUT_LSB       = 0x3C;
+    static const uint8_t ACCEL_Y_OUT_MSB       = 0x3D;
+    static const uint8_t ACCEL_Y_OUT_LSB       = 0x3E;
+    static const uint8_t ACCEL_Z_OUT_MSB       = 0x3F;
+    static const uint8_t ACCEL_Z_OUT_LSB       = 0x40;
+    static const uint8_t GYRO_X_OUT_MSB        = 0x43;
+    static const uint8_t GYRO_X_OUT_LSB        = 0x44;
+    static const uint8_t GYRO_Y_OUT_MSB        = 0x45;
+    static const uint8_t GYRO_Y_OUT_LSB        = 0x46;
+    static const uint8_t GYRO_Z_OUT_MSB        = 0x47;
+    static const uint8_t GYRO_Z_OUT_LSB        = 0x48;
+    static const uint8_t EXT_SENS_DATA_00      = 0x49;
+    static const uint8_t USER_CTRL_REG         = 0x6A;
+    static const uint8_t PWR_MGMT_REG          = 0x6B;
+    static const uint8_t WHOAMI_REG            = 0x75;
+
+    // MPU9250 register bits
+    static const uint8_t READ_FLAG     = 0x80;
+    static const uint8_t WRITE_FLAG    = 0x7f;
+    static const uint8_t WHOAMI_ID     = 0x71;
+
+    // I2C master status register bits
+    static const uint8_t I2C_MST_SLV4_NACK = 0x10;
+    static const uint8_t I2C_MST_SLV4_DONE = 0x40;
+
+    // I2C SLV register bits
+    static const uint8_t I2CSLV_EN     = 0x80;
+
+    // Power management and clock selection
+    static const uint8_t PWRMGMT_IMU_RST   = 0x80;
+    static const uint8_t PWRMGMT_PLL_X_CLK = 0x01;
+
+    // User control registers
+    static const uint8_t USERCTL_DIS_I2C       = 0x10;
+    static const uint8_t USERCTL_I2C_MST_EN    = 0x20;
+    static const uint8_t USERCTL_GYRO_RST      = 0x01;
+
+private:
+    Spi&                    spi_;              ///< SPI peripheral
+    Gpio&                   nss_;              ///< Slave Select GPIO
+    std::array<float, 3>    acc_data_;         ///< Accelerometer data
+    std::array<float, 3>    gyro_data_;        ///< Gyroscope data
+    std::array<float, 3>    mag_data_;         ///< Magnetometer data
+    float                   temperature_;      ///< Temperature
+    float                   last_update_us_;   ///< Last udate time in microseconds
+    conf_t                  config_;           ///< Device configuration
+    float                   acc_scale_;        ///< Acceleromter data scaling factor
+    float                   gyro_scale_;       ///< Gyroscope data scaling factor
+
+    /**
+     * \brief   Set accelerometer lowpass filter cut-off frequency
+     *
+     * \return  success
+     */
+    bool set_acc_lpf(void);
+
+    /**
+     * \brief   Set gyrometer lowpass filter cut-off frequency
+     *
+     * \return  success
+     */
+    bool set_gyro_lpf(void);
+
+    /**
+     * \brief   Set sampling frequency of acc and gyro axes
+     *
+     * \return  success
+     */
+    bool set_mpu_sample_rate(void);
+
+    /**
+     * \brief   Set operating mode of mag
+     *
+     * \detail  Set the mode of measurments (single,
+     *          continuous, ...) and the format of the
+     *          raw data (14, 16 bits)
+     *
+     * \return  success
+     */
+    bool set_mag_mode(void);
+
+    /**
+     * \brief   Set operating range of accelerometer
+     *
+     * \return  success
+     */
+    bool set_acc_range(void);
+
+    /**
+     * \brief   Set operating range of gyroscope
+     *
+     * \return  success
+     */
+    bool set_gyro_range(void);
+
+    /**
+     * \brief   Select Slave
+     */
+    void select_slave(void);
+
+    /**
+     * \brief   Unselect Slave
+     */
+    void unselect_slave(void);
+
+};
+
+#endif /* MPU_9250_HPP_ */

--- a/hal/stm32/spi_stm32.hpp
+++ b/hal/stm32/spi_stm32.hpp
@@ -51,13 +51,13 @@ extern "C"
 }
 
 /**
- * @brief   Enumerate the possible SPIs
+ * \brief   Enum of the available SPIs
  */
 typedef enum
 {
-    STM32_SPI1             = SPI1,
-    STM32_SPI2             = SPI2,
-    STM32_SPI3             = SPI3,
+    STM32_SPI1  = SPI1,
+    STM32_SPI2  = SPI2,
+    STM32_SPI3  = SPI3,
 } spi_stm32_devices_t;
 
 
@@ -66,29 +66,29 @@ typedef enum
  */
 typedef enum
 {
-    STM32_SPI_OFF       = 0,
-    STM32_SPI_IN        = 1,
-    STM32_SPI_OUT       = 2,
-    STM32_SPI_IN_OUT    = 3,
+    STM32_SPI_MODE_CPOL0_CPHA0  = 0,
+    STM32_SPI_MODE_CPOL0_CPHA1  = 1,
+    STM32_SPI_MODE_CPOL1_CPHA0  = 2,
+    STM32_SPI_MODE_CPOL1_CPHA1  = 3,
 } spi_stm32_mode_t;
 
 /**
- * @brief   Configuration structure
+ * \brief   Configuration structure
  */
 typedef struct
 {
-    spi_stm32_devices_t     spi_device;
-    spi_stm32_mode_t        mode;
+    spi_stm32_devices_t     spi_device;         ///< Spi id
+    spi_stm32_mode_t        mode;               ///< Clock mode (pol and phase)
     uint8_t                 clk_div;            ///< fp clock division
+    bool                    ss_mode_hard;       ///< Slave Select Mode Hardware/Software
     gpio_stm32_conf_t       miso_gpio_config;   ///< Master Out Slave In config
     gpio_stm32_conf_t       mosi_gpio_config;   ///< Master In Slave Out config
-    gpio_stm32_conf_t       nss_gpio_config;    ///< Slave Select config
     gpio_stm32_conf_t       sck_gpio_config;    ///< Serial Clock config
 } spi_stm32_conf_t;
 
 
 /**
- * @brief   Implementation of spi peripheral for stm32
+ * \brief   Implementation of spi peripheral for stm32
  */
 class Spi_stm32: public Spi
 {
@@ -97,7 +97,7 @@ public:
     /**
      * \brief   Initialises the peripheral
      *
-     * \param   config      Device configuration
+     * \param   config          Device configuration
      */
     Spi_stm32(spi_stm32_conf_t spi_config);
 
@@ -115,7 +115,7 @@ public:
      * \brief   Write bytes on the spi line
      *
      * \param   byte        Outgoing bytes
-     * \param   size        Number of bytes to write
+     * \param   nbytes      Number of bytes to write
      *
      * \return  true        Data successfully written
      * \return  false       Data not written
@@ -126,9 +126,8 @@ public:
     /**
      * \brief   Read bytes from the spi line
      *
-     * \param   command     Reading command
      * \param   bytes       Incoming bytes
-     * \param   size        Number of bytes to read
+     * \param   nbytes      Number of bytes to read
      *
      * \return  true        Data successfully read
      * \return  false       Data not read
@@ -146,6 +145,16 @@ public:
      * \return  false       Failed
      */
     bool transfer(uint8_t* out_buffer, uint8_t* in_buffer, uint32_t nbytes);
+
+    /**
+     * \brief   Select slave
+     */
+    void select_slave(void);
+
+    /**
+     * \brief   Unselect slave
+     */
+    void unselect_slave(void);
 
 
 private:

--- a/mission/mission_handler_manual.cpp
+++ b/mission/mission_handler_manual.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file mission_handler_manual.cpp
+ *
+ * \author MAV'RIC Team
+ * \author Matthew Douglas
+ *
+ * \brief The MAVLink mission planner handler for the manual control state
+ *
+ ******************************************************************************/
+
+
+#include "mission/mission_handler_manual.hpp"
+
+extern "C"
+{
+
+}
+
+
+//------------------------------------------------------------------------------
+// PUBLIC FUNCTIONS IMPLEMENTATION
+//------------------------------------------------------------------------------
+
+Mission_handler_manual::Mission_handler_manual(Navigation& navigation):
+            Mission_handler(),
+            navigation_(navigation)
+{
+}
+
+bool Mission_handler_manual::can_handle(const Waypoint& wpt) const
+{
+    // TODO: Check if actually on ground
+    return wpt.command() == MAV_CMD_NAV_MANUAL_CTRL;
+}
+
+bool Mission_handler_manual::setup(Mission_planner& mission_planner, const Waypoint& wpt)
+{
+    navigation_.set_waiting_at_waypoint(false);
+    return true;
+}
+
+void Mission_handler_manual::handle(Mission_planner& mission_planner)
+{
+}
+
+bool Mission_handler_manual::is_finished(Mission_planner& mission_planner)
+{
+    return true;
+}
+
+Mission_planner::internal_state_t Mission_handler_manual::handler_mission_state() const
+{
+    return Mission_planner::MANUAL_CTRL;
+}

--- a/mission/mission_handler_manual.hpp
+++ b/mission/mission_handler_manual.hpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file mission_handler_manual.hpp
+ *
+ * \author MAV'RIC Team
+ * \author Matthew Douglas
+ *
+ * \brief The MAVLink mission planner handler for the manual control state
+ *
+ ******************************************************************************/
+
+
+#ifndef MISSION_HANDLER_MANUAL__
+#define MISSION_HANDLER_MANUAL__
+
+#include "mission/mission_handler.hpp"
+#include "mission/navigation.hpp"
+
+/*
+ * N.B.: Reference Frames and MAV_CMD_NAV are defined in "maveric.h"
+ */
+
+class Mission_handler_manual : public Mission_handler
+{
+public:
+
+
+    /**
+     * \brief   Initialize the manual mission planner handler
+     *
+     * \param   navigation              The reference to the navigation class
+     */
+     Mission_handler_manual(Navigation& navigation);
+
+
+    /**
+     * \brief   Checks if the waypoint is on the ground
+     *
+     * \details     DOES NOT CURRENTLY CHECK IF WE ARE IN MANUAL CONTROL
+     *
+     * \param   wpt                 The waypoint class
+     *
+     * \return  Can handle
+     */
+    virtual bool can_handle(const Waypoint& wpt) const;
+
+    /**
+     * \brief   Does nothing
+     *
+     * \details     Does nothing
+     *
+     * \param   mission_planner     The mission planner class
+     * \param   wpt                 The waypoint class
+     *
+     * \return  True
+     */
+    virtual bool setup(Mission_planner& mission_planner, const Waypoint& wpt);
+
+    /**
+     * \brief   Does nothing
+     *
+     * \details     Does nothing
+     *
+     * \param   mission_planner     The mission planner class
+     */
+    virtual void handle(Mission_planner& mission_planner);
+
+    /**
+     * \brief   Returns true
+     *
+     * \details     Returns true as the manual control should switch whenever
+     *              we enter another auto state
+     *
+     * \param   mission_planner     The mission planner class
+     *
+     * \return  False
+     */
+    virtual bool is_finished(Mission_planner& mission_planner);
+
+    /**
+     * \brief   Returns that the mission state is in MANUAL_CTRL
+     *
+     * \return  Mission handler's mission state
+     */
+    virtual Mission_planner::internal_state_t handler_mission_state() const;
+
+protected:
+    Navigation& navigation_;                                    ///< The reference to the navigation structure
+};
+
+
+
+
+
+
+
+#endif // MISSION_HANDLER_MANUAL__

--- a/mission/mission_handler_takeoff.cpp
+++ b/mission/mission_handler_takeoff.cpp
@@ -124,9 +124,9 @@ bool Mission_handler_takeoff::is_finished(Mission_planner& mission_planner)
     // Determine distance to the waypoint
     if (waypoint_.autocontinue() == 1)
     {
-        float xy_radius_sqr = navigation_.takeoff_altitude*navigation_.takeoff_altitude*0.16f;
-
         local_position_t wpt_pos = waypoint_.local_pos();
+        float xy_radius_sqr = wpt_pos[Z]*wpt_pos[Z]*0.16f;
+        
         float xy_dist2wp_sqr;
         float rel_pos[3];
         for (int i = 0; i < 2; i++)
@@ -140,7 +140,7 @@ bool Mission_handler_takeoff::is_finished(Mission_planner& mission_planner)
         switch(navigation_.navigation_strategy)
         {
         case Navigation::strategy_t::DIRECT_TO:
-           if (xy_dist2wp_sqr <= xy_radius_sqr && ins_.position_lf()[Z] <= 0.9f * navigation_.takeoff_altitude)
+           if (xy_dist2wp_sqr <= xy_radius_sqr && ins_.position_lf()[Z] <= 0.9f * wpt_pos[Z])
             {
                 finished = true;
                 navigation_.set_waiting_at_waypoint(true);
@@ -150,7 +150,7 @@ bool Mission_handler_takeoff::is_finished(Mission_planner& mission_planner)
         case Navigation::strategy_t::DUBIN:
             if (state_.autopilot_type == MAV_TYPE_QUADROTOR)
             {
-                if (xy_dist2wp_sqr <= xy_radius_sqr && ins_.position_lf()[Z] <= 0.9f * navigation_.takeoff_altitude)
+                if (xy_dist2wp_sqr <= xy_radius_sqr && ins_.position_lf()[Z] <= 0.9f * wpt_pos[Z])
                 {
                     finished = true;
                     navigation_.set_waiting_at_waypoint(true);
@@ -158,7 +158,7 @@ bool Mission_handler_takeoff::is_finished(Mission_planner& mission_planner)
             }
             else
             {
-                if (ins_.position_lf()[Z] <= 0.9f * navigation_.takeoff_altitude)
+                if (ins_.position_lf()[Z] <= 0.9f * wpt_pos[Z])
                 {
                     finished = true;
                     navigation_.set_waiting_at_waypoint(true);

--- a/mission/mission_planner.cpp
+++ b/mission/mission_planner.cpp
@@ -530,7 +530,7 @@ void Mission_planner::state_machine()
             if (internal_state_ == STANDBY && manual_control_.get_thrust() > -0.7f)
             {
                 inserted_waypoint_ = Waypoint(  MAV_FRAME_LOCAL_NED,
-                                                MAV_CMD_NAV_LOITER_UNLIM,
+                                                MAV_CMD_NAV_TAKEOFF,
                                                 0,
                                                 0.0f,
                                                 0.0f,
@@ -540,6 +540,7 @@ void Mission_planner::state_machine()
                                                 ins_.position_lf()[Y],
                                                 navigation_.takeoff_altitude);
                 insert_ad_hoc_waypoint(inserted_waypoint_);
+                require_takeoff_ = false;
                 hold_position_set_ = true;
             }
 
@@ -892,6 +893,13 @@ bool Mission_planner::init()
 bool Mission_planner::update(Mission_planner* mission_planner)
 {
     Mav_mode mode_local = mission_planner->state_.mav_mode();
+
+    // Reset to standby if disarmed
+    if (!state_.is_armed() && mission_planner->internal_state() != STANDBY)
+    {
+        mission_planner->inserted_waypoint_ = Waypoint();
+        mission_planner->switch_mission_handler(mission_planner->inserted_waypoint_);
+    }
 
     switch (mission_planner->state_.mav_state_)
     {

--- a/mission/mission_planner.cpp
+++ b/mission/mission_planner.cpp
@@ -538,6 +538,7 @@ void Mission_planner::state_machine()
                                                 ins_.position_lf()[Z]);
                 // Insert so we can say to go back to doing last mission item afterwords
                 insert_ad_hoc_waypoint(inserted_waypoint_);
+                hold_position_set_ = true;
             }
 
             if (current_mission_handler_ != NULL)

--- a/mission/mission_planner.cpp
+++ b/mission/mission_planner.cpp
@@ -526,6 +526,23 @@ void Mission_planner::state_machine()
 
         if (state_.mav_mode().ctrl_mode() == Mav_mode::POSITION_HOLD) // Do position hold
         {
+            // Take off if on ground and thrust is on
+            if (internal_state_ == STANDBY && manual_control_.get_thrust() > -0.7f)
+            {
+                inserted_waypoint_ = Waypoint(  MAV_FRAME_LOCAL_NED,
+                                                MAV_CMD_NAV_LOITER_UNLIM,
+                                                0,
+                                                0.0f,
+                                                0.0f,
+                                                0.0f,
+                                                coord_conventions_get_yaw(ahrs_.qe),
+                                                ins_.position_lf()[X],
+                                                ins_.position_lf()[Y],
+                                                navigation_.takeoff_altitude);
+                insert_ad_hoc_waypoint(inserted_waypoint_);
+                hold_position_set_ = true;
+            }
+
             // Set hold position if needed
             if (!hold_position_set_)
             {
@@ -535,7 +552,7 @@ void Mission_planner::state_machine()
                                                 0.0f,
                                                 0.0f,
                                                 0.0f,
-                                                coord_conventions_get_yaw(ahrs_),
+                                                coord_conventions_get_yaw(ahrs_.qe),
                                                 ins_.position_lf()[X],
                                                 ins_.position_lf()[Y],
                                                 ins_.position_lf()[Z]);

--- a/mission/mission_planner.cpp
+++ b/mission/mission_planner.cpp
@@ -135,7 +135,7 @@ mav_result_t Mission_planner::continue_to_next_waypoint(Mission_planner* mission
                                          mission_planner->mavlink_stream_.compid(),
                                          &msg,
                                          mission_planner->waypoint_handler_.current_waypoint_index());
-        mission_planner->mavlink_stream_.send(&msg);      
+        mission_planner->mavlink_stream_.send(&msg);
 
         result = MAV_RESULT_ACCEPTED;
     }
@@ -391,12 +391,15 @@ mav_result_t Mission_planner::set_auto_landing(Mission_planner* mission_planner,
 
 void Mission_planner::state_machine()
 {
+    // Reset hold position flag as we are not in hold position mode
+    if (state_.mav_mode().ctrl_mode() != Mav_mode::POSITION_HOLD)
+    {
+        hold_position_set_ = false;
+    }
+
     // If is auto, look to the waypoints
     if (state_.mav_mode().is_auto())
     {
-        // Reset hold position flag as we are now in auto mode
-        hold_position_set_ = false;
-
         // Require takeoff if we have switched out of auto, dont take off if on ground
         if (require_takeoff_ &&
            (internal_state_ != STANDBY ||
@@ -517,7 +520,7 @@ void Mission_planner::state_machine()
             }
         }
     }
-    else 
+    else
     {
         require_takeoff_ = true;
 
@@ -957,14 +960,14 @@ bool Mission_planner::switch_mission_handler(const Waypoint& waypoint)
     {
         print_util_dbg_print("Cannot setup mission handler\r\n");
     }
-    
+
     return ret;
 }
 
 bool Mission_planner::insert_ad_hoc_waypoint(Waypoint wpt)
 {
     bool ret = true;
-    
+
     // Copy waypoint state in case of failure
     Waypoint old = inserted_waypoint_;
     inserted_waypoint_ = wpt;

--- a/mission/mission_planner.cpp
+++ b/mission/mission_planner.cpp
@@ -535,7 +535,7 @@ void Mission_planner::state_machine()
                                                 0.0f,
                                                 0.0f,
                                                 0.0f,
-                                                0.0f,
+                                                coord_conventions_get_yaw(ahrs_),
                                                 ins_.position_lf()[X],
                                                 ins_.position_lf()[Y],
                                                 ins_.position_lf()[Z]);

--- a/mission/mission_planner.hpp
+++ b/mission/mission_planner.hpp
@@ -70,7 +70,8 @@ public:
         PREMISSION,
         MISSION,
         POSTMISSION,
-        PAUSED
+        PAUSED,
+        MANUAL_CTRL
     };
 
     /**
@@ -163,7 +164,7 @@ public:
 
     /**
      * \brief   Inserts the inputted waypoint into the mission
-     * 
+     *
      * \details     This inserts a waypoint into the mission and sets
      *              the internal state to paused. If the insert fails,
      *              the function returns false and does not set the

--- a/mission/navigation.cpp
+++ b/mission/navigation.cpp
@@ -557,6 +557,13 @@ bool Navigation::update(Navigation* navigation)
             {
                 navigation->run();
             }
+            else
+            {
+                navigation->controls_nav.tvel[X] = 0.0f;
+                navigation->controls_nav.tvel[Y] = 0.0f;
+                navigation->controls_nav.tvel[Z] = 10.0f;
+                navigation->controls_nav.theading = 0.0f;
+            }
             break;
 
         case MAV_STATE_CRITICAL:
@@ -579,7 +586,7 @@ bool Navigation::update(Navigation* navigation)
             navigation->controls_nav.tvel[Z] = 0.0f;
             break;
     }
-    
+
     return true;
 }
 

--- a/mission/navigation.hpp
+++ b/mission/navigation.hpp
@@ -73,7 +73,7 @@ public:
         DUBIN = 1,
     };
 
-    
+
 
     /**
      * \brief The navigation configuration structure
@@ -284,8 +284,8 @@ Navigation::conf_t Navigation::default_config()
     conf.heading_acceptance                          = PI/6.0f;
     conf.vertical_vel_gain                           = 1.0f;
     conf.takeoff_altitude                            = -10.0f;
-    //conf.navigation_strategy                         = Navigation::strategy_t::DIRECT_TO;
-    conf.navigation_strategy                         = Navigation::strategy_t::DUBIN;
+    conf.navigation_strategy                         = Navigation::strategy_t::DIRECT_TO;
+    //conf.navigation_strategy                         = Navigation::strategy_t::DUBIN;
     return conf;
 };
 

--- a/rules_common.mk
+++ b/rules_common.mk
@@ -88,6 +88,7 @@ LIB_SRCS += drivers/gps_mocap.cpp
 LIB_SRCS += drivers/hmc5883l.cpp
 LIB_SRCS += drivers/lsm330dlc.cpp
 LIB_SRCS += drivers/mpu_6050.cpp
+LIB_SRCS += drivers/mpu_9250.cpp
 LIB_SRCS += drivers/px4flow_i2c.cpp
 LIB_SRCS += drivers/servo.cpp
 LIB_SRCS += drivers/servos_telemetry.cpp

--- a/rules_common.mk
+++ b/rules_common.mk
@@ -109,6 +109,7 @@ LIB_SRCS += mission/mission_handler_critical_landing.cpp
 LIB_SRCS += mission/mission_handler_critical_navigating.cpp
 LIB_SRCS += mission/mission_handler_hold_position.cpp
 LIB_SRCS += mission/mission_handler_landing.cpp
+LIB_SRCS += mission/mission_handler_manual.cpp
 LIB_SRCS += mission/mission_handler_navigating.cpp
 LIB_SRCS += mission/mission_handler_on_ground.cpp
 LIB_SRCS += mission/mission_handler_registry.cpp

--- a/sample_projects/LEQuad/lequad.cpp
+++ b/sample_projects/LEQuad/lequad.cpp
@@ -96,6 +96,7 @@ LEQuad::LEQuad(Imu& imu, Barometer& barometer, Gps& gps, Sonar& sonar, Serial& s
     landing_handler(position_estimation, navigation, state),
     navigating_handler(position_estimation, navigation, mavlink_communication_.mavlink_stream(), waypoint_handler),
     on_ground_handler(navigation),
+    manual_ctrl_handler(navigation),
     takeoff_handler(position_estimation, navigation, state),
     critical_landing_handler(position_estimation, navigation, state),
     critical_navigating_handler(position_estimation, navigation, mavlink_communication_.mavlink_stream(), waypoint_handler),
@@ -452,6 +453,7 @@ bool LEQuad::init_navigation(void)
     // Initialize
     ret &= mission_handler_registry.register_mission_handler(hold_position_handler);
     ret &= mission_handler_registry.register_mission_handler(landing_handler);
+    ret &= mission_handler_registry.register_mission_handler(manual_ctrl_handler);
     ret &= mission_handler_registry.register_mission_handler(navigating_handler);
     ret &= mission_handler_registry.register_mission_handler(on_ground_handler);
     ret &= mission_handler_registry.register_mission_handler(takeoff_handler);

--- a/sample_projects/LEQuad/lequad.cpp
+++ b/sample_projects/LEQuad/lequad.cpp
@@ -84,11 +84,11 @@ LEQuad::LEQuad(Imu& imu, Barometer& barometer, Gps& gps, Sonar& sonar, Serial& s
     servo_7(servo_7),
     manual_control(&satellite, config.manual_control_config, config.remote_config),
     state(mavlink_communication_.mavlink_stream(), battery, config.state_config),
-    scheduler(Scheduler::default_config()),
+    scheduler(config.scheduler_config),
     mavlink_communication_(serial_mavlink, state, file_flash, config.mavlink_communication_config),
     ahrs(ahrs_initialized()),
     ahrs_ekf(imu, ahrs, config.ahrs_ekf_config),
-    position_estimation(state, barometer, sonar, gps, ahrs),
+    position_estimation(state, barometer, sonar, gps, ahrs, config.position_estimation_config),
     mission_handler_registry(),
     navigation(controls_nav, ahrs.qe, position_estimation, state, mavlink_communication_.mavlink_stream(), mission_handler_registry, config.navigation_config),
     waypoint_handler(position_estimation, navigation, state, mavlink_communication_.message_handler(), mavlink_communication_.mavlink_stream(), mission_handler_registry, config.waypoint_handler_config),
@@ -456,7 +456,7 @@ bool LEQuad::init_navigation(void)
     ret &= mission_handler_registry.register_mission_handler(on_ground_handler);
     ret &= mission_handler_registry.register_mission_handler(takeoff_handler);
     ret &= mission_handler_registry.register_mission_handler(critical_landing_handler);
-    ret &= mission_handler_registry.register_mission_handler(critical_navigating_handler); 
+    ret &= mission_handler_registry.register_mission_handler(critical_navigating_handler);
     ret &= waypoint_handler.init();
     ret &= mission_planner.init();
 

--- a/sample_projects/LEQuad/lequad.hpp
+++ b/sample_projects/LEQuad/lequad.hpp
@@ -57,6 +57,7 @@
 #include "mission/mission_handler_critical_navigating.hpp"
 #include "mission/mission_handler_hold_position.hpp"
 #include "mission/mission_handler_landing.hpp"
+#include "mission/mission_handler_manual.hpp"
 #include "mission/mission_handler_navigating.hpp"
 #include "mission/mission_handler_on_ground.hpp"
 #include "mission/mission_handler_takeoff.hpp"
@@ -255,6 +256,7 @@ protected:
     Mission_handler_landing landing_handler;
     Mission_handler_navigating navigating_handler;
     Mission_handler_on_ground on_ground_handler;
+    Mission_handler_manual manual_ctrl_handler;
     Mission_handler_takeoff takeoff_handler;
     Mission_handler_critical_landing critical_landing_handler;
     Mission_handler_critical_navigating critical_navigating_handler;

--- a/sample_projects/LEQuad/main_linux.cpp
+++ b/sample_projects/LEQuad/main_linux.cpp
@@ -52,7 +52,7 @@ extern "C"
 
 int main(int argc, char** argv)
 {
-    uint8_t sysid = 0;
+    uint8_t sysid = 1;
     bool init_success = true;
 
     // -------------------------------------------------------------------------

--- a/sample_projects/LEQuad/main_sparky_v2.cpp
+++ b/sample_projects/LEQuad/main_sparky_v2.cpp
@@ -40,21 +40,23 @@
 
 #include "boards/sparky_v2.hpp"
 
-#include "sample_projects/LEQuad/lequad.hpp"
+#include "drivers/mpu_9250.hpp"
+#include "drivers/spektrum_satellite.hpp"
+
 #include "hal/common/time_keeper.hpp"
-
-#include "hal/stm32/spi_stm32.hpp"
-
 #include "hal/dummy/serial_dummy.hpp"
 #include "hal/dummy/i2c_dummy.hpp"
 #include "hal/dummy/file_dummy.hpp"
 #include "hal/dummy/adc_dummy.hpp"
 #include "hal/dummy/pwm_dummy.hpp"
+#include "hal/stm32/spi_stm32.hpp"
+
+#include "sample_projects/LEQuad/lequad.hpp"
 
 #include "simulation/dynamic_model_quad_diag.hpp"
 #include "simulation/simulation.hpp"
 
-#include "drivers/spektrum_satellite.hpp"
+#include "util/string_util.hpp"
 
 extern "C"
 {
@@ -71,7 +73,26 @@ int main(int argc, char** argv)
     // Create board
     // -------------------------------------------------------------------------
     sparky_v2_conf_t board_config = sparky_v2_default_config();
+
+    // board_config.imu_config.accelerometer.bias[0] = -0.0327504f;
+    // board_config.imu_config.accelerometer.bias[1] = -0.00344232f;
+    // board_config.imu_config.accelerometer.bias[2] = +0.00931478f;
+
+    // board_config.imu_config.gyroscope.bias[0] = -0.0135339f;
+    // board_config.imu_config.gyroscope.bias[1] = -0.0061096f;
+    // board_config.imu_config.gyroscope.bias[2] = -0.00312137f;
+
+    // board_config.imu_config.magnetometer.bias[0] = +0.520405f;
+    // board_config.imu_config.magnetometer.bias[1] = -0.55305f;
+    // board_config.imu_config.magnetometer.bias[2] = -0.489245f;
+
+    // board_config.imu_config.magnetic_north[0] = +0.268271f;
+    // board_config.imu_config.magnetic_north[1] = +0.0f;
+    // board_config.imu_config.magnetic_north[2] = +0.485027f;
+
     Sparky_v2 board(board_config);
+
+
 
     // Board initialisation
     init_success &= board.init();
@@ -122,7 +143,7 @@ int main(int argc, char** argv)
                          board.serial_,                // mavlink serial
                          satellite_dummy,
                          board.state_display_sparky_v2_,
-                        file_dummy,
+                         file_dummy,
                          sim_battery,
                          sim_servo_0,
                          sim_servo_1,
@@ -168,6 +189,57 @@ int main(int argc, char** argv)
     // Main loop
     // -------------------------------------------------------------------------
     mav.loop();
+
+    // board.led_err_.off();
+    // board.led_stat_.off();
+    // board.led_rf_.off();
+
+    // Console<Serial> console(board.serial_);
+
+    // while (1)
+    // {
+
+        // Write mavlink message
+        // mavlink_msg_heartbeat_pack( 11,     // uint8_t system_id,
+        //                             50,     // uint8_t component_id,
+        //                             &msg,   // mavlink_message_t* msg,
+        //                             0,      // uint8_t type,
+        //                             0,      // uint8_t autopilot,
+        //                             0,      // uint8_t base_mode,
+        //                             0,      // uint32_t custom_mode,
+        //                             0);     //uint8_t system_status)
+        // mavlink_stream.send(&msg);
+
+    //     time_keeper_delay_ms(500);
+
+
+    //     const char* sep = "\t";
+    //     uint64_t delay = 25;
+
+    //     console.write(valx);
+    //     time_keeper_delay_ms(delay);
+    //     board.serial_.write((const uint8_t*)sep, sizeof(sep));
+    //     time_keeper_delay_ms(delay);
+    //     console.write(valy);
+    //     time_keeper_delay_ms(delay);
+    //     board.serial_.write((const uint8_t*)sep, sizeof(sep));
+    //     time_keeper_delay_ms(delay);
+    //     console.write(valz);
+    //     time_keeper_delay_ms(delay);
+
+    //     const char* newline = "\r\n";
+    //     board.serial_.write((const uint8_t*)newline, sizeof(newline));
+
+    //     if (bo)
+    //     {
+    //         board.led_stat_.toggle();
+    //     }
+    //     else
+    //     {
+    //         board.led_err_.toggle();
+    //     }
+
+    // }
 
     return 0;
 }

--- a/sensing/imu.cpp
+++ b/sensing/imu.cpp
@@ -78,7 +78,7 @@ Imu::Imu(Accelerometer& accelerometer, Gyroscope& gyroscope, Magnetometer& magne
 
 bool Imu::update(void)
 {
-    bool success = false;
+    bool success = true;
 
     // Update timing
     uint32_t t      = time_keeper_get_us();
@@ -102,7 +102,7 @@ bool Imu::update(void)
         oriented_gyro_[i] = raw_gyro[ config_.gyroscope.axis[i]     ] * config_.gyroscope.sign[i];
         oriented_mag_[i]  = raw_mag[  config_.magnetometer.axis[i]  ] * config_.magnetometer.sign[i];
     }
-
+    
     // Scale sensor values
     float new_scaled_acc[3];
     float new_scaled_gyro[3];
@@ -113,7 +113,7 @@ bool Imu::update(void)
         new_scaled_acc[i]  = oriented_acc_[i]  / config_.accelerometer.scale_factor[i] - config_.accelerometer.bias[i];
         new_scaled_gyro[i] = oriented_gyro_[i] / config_.gyroscope.scale_factor[i]     - config_.gyroscope.bias[i];
         new_scaled_mag[i]  = oriented_mag_[i]  / config_.magnetometer.scale_factor[i]  - config_.magnetometer.bias[i];
-
+    
         // Low pass filter
         scaled_acc_[i]  = config_.lpf_acc   * new_scaled_acc[i]  + (1.0f - config_.lpf_acc) * scaled_acc_[i];
         scaled_gyro_[i] = config_.lpf_gyro  * new_scaled_gyro[i] + (1.0f - config_.lpf_gyro) * scaled_gyro_[i];


### PR DESCRIPTION
Fixes Issue #306.

This is still a work in progress but there have been several major changes to the Mavlink_waypoint_handler class as well as the creation of several other classes.

Changes that have been made already:
- The [waypoint class](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/waypoint.hpp)
  - A Waypoint class has been created and both other waypoint structures have been removed. 
  - The waypoint stores most of its parameters as member fields. The current field is no longer a part of the waypoint. It must be passed to the waypoint when sending the message to the ground control station. The reason for this is that the waypoint should not need to know if it is the current waypoint, just the physical properties as well as some options set by the user. In addition, the x, y, and z fields are no longer stored by themselves as they are stored as a global position.
  - The waypoint can send itself as a mavlink message by calling the `Waypoint::send()` function and passing in the appropriate arguments.
  - The waypoint class can set and retrieve the local position of the waypoint. This will convert its global position to the local position.
- The [Mavlink_waypoint_handler](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/communication/mavlink_waypoint_handler.hpp) has been greatly reduced. 
  - This class is now only responsible for the creation, deletion, reception, transmission, and retrieval of the waypoints. 
  - Various redundant variables have been removed.
  - The waypoints can be retrieved via the public functions `Mavlink_waypoint_handler::current_waypoint()`, `Mavlink_waypoint_handler::next_waypoint()`, and `Mavlink_waypoint_handler::waypoint_from_index(int i)`.
  - The waypoint index can be advanced by calling `Mavlink_waypoint_handler::advance_to_next_waypoint()`.
  - The sending and receiving waypoint function logic has been largely unchanged.
- The [mission planner class](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner.hpp)
  - A Mission_planner class has been created that is responsible for planning the mission. It determines which handler to call based off of the state of the drone. It also contains the callback functions from the old Mavlink_waypoint_handler that were related to the mission planning.
  - The critical handler has been largely unchanged
  - The state machine now calls various Mission_planner_handler classes based off the drone state.
  - The mission planner no longer contains waypoint_next_, next_waypoint, current_waypoint_, etc. Instead, these waypoints should be obtained by requesting them from the Mavlink_waypoint_handler.
- A [mission planner handler class](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler.hpp) has been created.
  - An abstract Mission_planner_handler class has been created that is called by the mission planner state machine function. The child classes should determine what to do with the waypoint goal based on the current state of the drone.
  - The current child classes are [Mission_planner_handler_hold_position](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_hold_position.hpp), [Mission_planner_handler_landing](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_landing.hpp), [Mission_planner_handler_manual_control](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_manual_control.hpp), [Mission_planner_handler_navigating](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_navigating.hpp), [Mission_planner_handler_on_ground](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_on_ground.hpp), [Mission_planner_handler_stop_on_position](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_stop_on_position.hpp), [Mission_planner_handler_stop_there](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_stop_there.hpp), and [Mission_planner_handler_takeoff](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/mission_planner_handler_takeoff.hpp).
  - If a custom mission planner handler needs to be made, the handle and init functions need to be defined.
  - This class contains private static members `hold_waypoint_ `and `hold_waypoint_set_` that should be set whenever the hold position needs to be changed. As they are private, these subclasses will therefore not have access to it but can manipulate them with the functions `reset_hold_waypoint()`, `hold_waypoint_set()`, `set_hold_waypoint(local_position_t hold_position)`, `set_hold_waypoint(local_position_t hold_position, float heading)`, `set_hold_waypoint(Waypoint wpt)`, and `hold_waypoint()`. These functions will automatically control both private variables. If something tries to access the hold_waypoint before it has been set (or after it has been reset), it will return the local position of the drone and set the hold waypoint.
- The [navigation class](https://github.com/lis-epfl/MAVRIC_Library/blob/5d03f2e376414d765692dfee3b0f9394b311fda0/control/navigation.hpp) has been modified
  - The goal waypoint has been made private, it is now accessed by the functions `goal()` and `set_goal(Waypoint wpt)`. 
  - The dubin control has been moved to the navigation class.
  - The dubin structure does not need to be reinitialized manually, the navigation class will reinitialize the goal if there is a slight change in the goal (slight as the parameters are mainly floats).
  - The internal state has been made private. It can be accessed by the functions `internal_state()` and `set_internal_state(internal_state_t new_internal_state)`. The set internal state will automatically output a debug message of a state change.
  - A waiting_at_waypoint_ boolean has been created. This is used for the various methods that need to know if the drone is en route or if the drone has arrived at the waypoint.

Things that still need to be changed:
- The critical state handler has been largely unchanged. This should probably be changed to a method similar to that of the regular mission planner state machine.
- The navigating handler is a little complex and should probably be changed
- There seems to be issues with the navigation path towards the goals. See issues #275 and #297. I do not believe that it is caused by an incorrect goal location.
- I think something should be done with the nav_plan_active boolean.
- Fix the landing for the fixed wing/dubin landing procedure.
- General code cleanup.

Some recommendations/comments would be very helpful.