### PR TITLE
spi configuration for mpu9250

### DIFF
--- a/boards/sparky_v2.cpp
+++ b/boards/sparky_v2.cpp
@@ -95,7 +95,7 @@ Sparky_v2::Sparky_v2(sparky_v2_conf_t config):
     servo_5_(pwm_5_, config.servo_config[5]),
     servo_6_(pwm_6_, config.servo_config[6]),
     servo_7_(pwm_7_, config.servo_config[7]),
-    //spi_1_(config.spi_config[0]),
+    spi_1_(config.spi_config[0]),
     spi_3_(config.spi_config[2]),
     state_display_sparky_v2_(led_stat_, led_err_)
 {}
@@ -263,7 +263,7 @@ bool Sparky_v2::init(void)
     // -------------------------------------------------------------------------
     // Init SPIs
     // -------------------------------------------------------------------------
-    //spi_1_.init();
+    spi_1_.init();
     spi_3_.init();
 
     return init_success;

--- a/boards/sparky_v2.cpp
+++ b/boards/sparky_v2.cpp
@@ -104,7 +104,7 @@ Sparky_v2::Sparky_v2(sparky_v2_conf_t config):
 bool Sparky_v2::init(void)
 {
     bool init_success = true;
-    bool ret = true;
+    bool ret;
 
     // -------------------------------------------------------------------------
     // Init clock
@@ -115,9 +115,9 @@ bool Sparky_v2::init(void)
     // -------------------------------------------------------------------------
     // Init LEDs
     // -------------------------------------------------------------------------
-    ret &= led_err_gpio_.init();
-    ret &= led_stat_gpio_.init();
-    ret &= led_rf_gpio_.init();
+    ret = led_err_gpio_.init();
+    ret = led_stat_gpio_.init();
+    ret = led_rf_gpio_.init();
     led_err_.on();
     led_stat_.on();
     led_rf_.on();
@@ -263,8 +263,9 @@ bool Sparky_v2::init(void)
     // -------------------------------------------------------------------------
     // Init SPIs
     // -------------------------------------------------------------------------
-    spi_1_.init();
-    spi_3_.init();
-
+    ret = spi_1_.init();
+    ret = spi_3_.init();
+    init_success &= ret;
+    
     return init_success;
 }

--- a/boards/sparky_v2.hpp
+++ b/boards/sparky_v2.hpp
@@ -148,7 +148,7 @@ public:
     Servo                   servo_5_;
     Servo                   servo_6_;
     Servo                   servo_7_;
-    //Spi_stm32               spi_1_;
+    Spi_stm32               spi_1_;
     Spi_stm32               spi_3_;
     State_display_sparky_v2 state_display_sparky_v2_;
 
@@ -280,7 +280,7 @@ static inline sparky_v2_conf_t sparky_v2_default_config()
     // -------------------------------------------------------------------------
     conf.spi_config[0].spi_device       = STM32_SPI1;
     conf.spi_config[0].mode             = STM32_SPI_IN_OUT;
-    //conf.spi_config[0].option         = ...;
+    conf.spi_config[0].clk_div          = SPI_CR1_BAUDRATE_FPCLK_DIV_128;
 
     conf.spi_config[0].miso_gpio_config.port    = GPIO_STM32_PORT_A;
     conf.spi_config[0].miso_gpio_config.pin     = GPIO_STM32_PIN_6;
@@ -300,16 +300,16 @@ static inline sparky_v2_conf_t sparky_v2_default_config()
     conf.spi_config[0].nss_gpio_config.pull     = GPIO_PULL_UPDOWN_NONE;
     conf.spi_config[0].nss_gpio_config.alt_fct  = GPIO_STM32_AF_5;
 
-    conf.spi_config[0].sck_gpio_config.port    = GPIO_STM32_PORT_A;
-    conf.spi_config[0].sck_gpio_config.pin     = GPIO_STM32_PIN_5;
-    conf.spi_config[0].sck_gpio_config.dir     = GPIO_OUTPUT;
-    conf.spi_config[0].sck_gpio_config.pull    = GPIO_PULL_UPDOWN_DOWN;
-    conf.spi_config[0].sck_gpio_config.alt_fct = GPIO_STM32_AF_5;
+    conf.spi_config[0].sck_gpio_config.port     = GPIO_STM32_PORT_A;
+    conf.spi_config[0].sck_gpio_config.pin      = GPIO_STM32_PIN_5;
+    conf.spi_config[0].sck_gpio_config.dir      = GPIO_OUTPUT;
+    conf.spi_config[0].sck_gpio_config.pull     = GPIO_PULL_UPDOWN_DOWN;
+    conf.spi_config[0].sck_gpio_config.alt_fct  = GPIO_STM32_AF_5;
 
 
     conf.spi_config[2].spi_device               = STM32_SPI3;
     conf.spi_config[2].mode                     = STM32_SPI_IN_OUT;
-    //conf.spi_config[0].option                 = ...;
+    conf.spi_config[2].clk_div                  = SPI_CR1_BAUDRATE_FPCLK_DIV_64;
 
     conf.spi_config[2].miso_gpio_config.port    = GPIO_STM32_PORT_C;
     conf.spi_config[2].miso_gpio_config.pin     = GPIO_STM32_PIN_11;
@@ -329,11 +329,11 @@ static inline sparky_v2_conf_t sparky_v2_default_config()
     conf.spi_config[2].nss_gpio_config.pull     = GPIO_PULL_UPDOWN_NONE;
     conf.spi_config[2].nss_gpio_config.alt_fct  = GPIO_STM32_AF_6;
 
-    conf.spi_config[2].sck_gpio_config.port    = GPIO_STM32_PORT_C;
-    conf.spi_config[2].sck_gpio_config.pin     = GPIO_STM32_PIN_10;
-    conf.spi_config[2].sck_gpio_config.dir     = GPIO_OUTPUT;
-    conf.spi_config[2].sck_gpio_config.pull    = GPIO_PULL_UPDOWN_DOWN;
-    conf.spi_config[2].sck_gpio_config.alt_fct = GPIO_STM32_AF_6;
+    conf.spi_config[2].sck_gpio_config.port     = GPIO_STM32_PORT_C;
+    conf.spi_config[2].sck_gpio_config.pin      = GPIO_STM32_PIN_10;
+    conf.spi_config[2].sck_gpio_config.dir      = GPIO_OUTPUT;
+    conf.spi_config[2].sck_gpio_config.pull     = GPIO_PULL_UPDOWN_DOWN;
+    conf.spi_config[2].sck_gpio_config.alt_fct  = GPIO_STM32_AF_6;
     return conf;
 }
 

--- a/hal/stm32/spi_stm32.cpp
+++ b/hal/stm32/spi_stm32.cpp
@@ -42,6 +42,12 @@
 #include "hal/stm32/spi_stm32.hpp"
 #include <cstddef>
 
+extern "C"
+{
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/rcc.h>
+}
+
 //------------------------------------------------------------------------------
 // PUBLIC FUNCTIONS IMPLEMENTATION
 //------------------------------------------------------------------------------
@@ -79,11 +85,10 @@ bool Spi_stm32::init(void)
     gpio_mode_setup(config_.nss_gpio_config.port, config_.nss_gpio_config.dir, config_.nss_gpio_config.pull, config_.nss_gpio_config.pin);
 
     // SPI configuration
-    cr_tmp =    SPI_CR1_BAUDRATE_FPCLK_DIV_8 |   // Clock frequency
-                SPI_CR1_MSTR |                   // Setting device as master
-                SPI_CR1_SPE  |                   // SPI enabled
-                SPI_CR1_CPHA |                   // Clock Phase
-                SPI_CR1_CPOL_CLK_TO_1_WHEN_IDLE; // Clock Polarity
+    cr_tmp =    config_.clk_div |   // Clock frequency   
+                SPI_CR1_MSTR    |   // Setting device as master
+                SPI_CR1_SPE     |   // SPI enabled
+                SPI_CR1_CPHA;       // Clock Phase
 
     switch (config_.spi_device)
     {

--- a/hal/stm32/spi_stm32.hpp
+++ b/hal/stm32/spi_stm32.hpp
@@ -44,17 +44,11 @@
 
 #include "hal/common/spi.hpp"
 #include "hal/stm32/gpio_stm32.hpp"
+
 extern "C"
 {
-#include <libopencm3/stm32/gpio.h>
-#include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/spi.h>
 }
-
-// extern "C"
-// {
-// #include "libs/asf/avr32/drivers/spi/spi.h"
-// }
 
 /**
  * @brief   Enumerate the possible SPIs
@@ -85,6 +79,7 @@ typedef struct
 {
     spi_stm32_devices_t     spi_device;
     spi_stm32_mode_t        mode;
+    uint8_t                 clk_div;            ///< fp clock division
     gpio_stm32_conf_t       miso_gpio_config;   ///< Master Out Slave In config
     gpio_stm32_conf_t       mosi_gpio_config;   ///< Master In Slave Out config
     gpio_stm32_conf_t       nss_gpio_config;    ///< Slave Select config

--- a/sample_projects/LEQuad/main_sparky_v2.cpp
+++ b/sample_projects/LEQuad/main_sparky_v2.cpp
@@ -48,10 +48,6 @@
 extern "C"
 {
 #include "util/print_util.h"
-
-#include <libopencm3/stm32/rcc.h>
-#include <libopencm3/stm32/gpio.h>
-#include <libopencm3/stm32/spi.h>
 }
 
 int main(int argc, char** argv)
@@ -73,10 +69,17 @@ int main(int argc, char** argv)
     // #############################################################################################
     Mavlink_stream mavlink_stream(board.serial_);
     mavlink_message_t msg;
+
+
+    // #############################################################################################
+    // #############  SPI test##################################################################
+    // #############################################################################################
+    uint8_t b[5] = {0x11,0x22,0x33,0x44,0x55};
+    uint8_t *bytes = b;
     
     while (1)
     {
-        //board.state_display_sparky_v2_.update();
+        board.state_display_sparky_v2_.update();
         // Warning: if too short serial does not work
         //time_keeper_delay_ms(1000);
 
@@ -91,8 +94,10 @@ int main(int argc, char** argv)
                                     0,      // uint32_t custom_mode,
                                     0);     //uint8_t system_status)
         mavlink_stream.send(&msg);
+
+        board.spi_1_.write(bytes,5);
+        board.spi_3_.write(bytes,5);
         
-        board.spi_3_.send(0xff);
         time_keeper_delay_ms(1);
     }
 


### PR DESCRIPTION
- Add spi configuration for mpu9250 on SPI1.
- SPI2 not used thus not configured.
- SPI3 for now has same config as SP1 but new config should be applied to communicate with RFM22B-S2 / Flash 16MBits memory
