### PR TITLE
Dynamic_model_telemetry sends HIL_STATE_QUATERNION

### DIFF
--- a/rules_common.mk
+++ b/rules_common.mk
@@ -125,6 +125,7 @@ LIB_SRCS += sensing/qfilter.cpp
 LIB_SRCS += simulation/accelerometer_sim.cpp
 LIB_SRCS += simulation/barometer_sim.cpp
 LIB_SRCS += simulation/dynamic_model_quad_diag.cpp
+LIB_SRCS += simulation/dynamic_model_telemetry.cpp
 LIB_SRCS += simulation/flow_sim.cpp
 LIB_SRCS += simulation/gps_sim.cpp
 LIB_SRCS += simulation/gyroscope_sim.cpp

--- a/sample_projects/LEQuad/lequad.cpp
+++ b/sample_projects/LEQuad/lequad.cpp
@@ -83,18 +83,18 @@ LEQuad::LEQuad(Imu& imu, Barometer& barometer, Gps& gps, Sonar& sonar, Serial& s
     servo_6(servo_6),
     servo_7(servo_7),
     manual_control(&satellite, config.manual_control_config, config.remote_config),
-    state(mavlink_communication.mavlink_stream(), battery, config.state_config),
+    state(mavlink_communication_.mavlink_stream(), battery, config.state_config),
     scheduler(Scheduler::default_config()),
-    mavlink_communication(serial_mavlink, state, file_flash, config.mavlink_communication_config),
+    mavlink_communication_(serial_mavlink, state, file_flash, config.mavlink_communication_config),
     ahrs(ahrs_initialized()),
     ahrs_ekf(imu, ahrs, config.ahrs_ekf_config),
     position_estimation(state, barometer, sonar, gps, ahrs),
-    navigation(controls_nav, ahrs.qe, position_estimation, state, mavlink_communication.mavlink_stream(), config.navigation_config),
-    waypoint_handler(position_estimation, navigation, ahrs, state, manual_control, mavlink_communication.message_handler(), mavlink_communication.mavlink_stream(), config.waypoint_handler_config),
+    navigation(controls_nav, ahrs.qe, position_estimation, state, mavlink_communication_.mavlink_stream(), config.navigation_config),
+    waypoint_handler(position_estimation, navigation, ahrs, state, manual_control, mavlink_communication_.message_handler(), mavlink_communication_.mavlink_stream(), config.waypoint_handler_config),
     state_machine(state, position_estimation, imu, ahrs, manual_control, state_display_),
     data_logging_continuous(file1, state, config.data_logging_continuous_config),
     data_logging_stat(file2, state, config.data_logging_stat_config),
-    sysid_(mavlink_communication.sysid()),
+    sysid_(mavlink_communication_.sysid()),
     config_(config)
 {
     // Init main task first
@@ -122,17 +122,17 @@ void LEQuad::loop(void)
 {
     // Sort tasks
     scheduler.sort_tasks();
-    mavlink_communication.scheduler().sort_tasks();
+    mavlink_communication_.scheduler().sort_tasks();
 
     // Try to read from flash, if unsuccessful, write to flash
-    if (mavlink_communication.onboard_parameters().read_parameters_from_storage() == false)
+    if (mavlink_communication_.onboard_parameters().read_parameters_from_storage() == false)
     {
-        mavlink_communication.onboard_parameters().write_parameters_to_storage();
+        mavlink_communication_.onboard_parameters().write_parameters_to_storage();
     }
 
     // Create log files
-    data_logging_continuous.create_new_log_file("log", true, mavlink_communication.sysid());
-    data_logging_stat.create_new_log_file("stat", false, mavlink_communication.sysid());
+    data_logging_continuous.create_new_log_file("log", true, mavlink_communication_.sysid());
+    data_logging_stat.create_new_log_file("stat", false, mavlink_communication_.sysid());
 
     // Init mav state
     state.mav_state_ = MAV_STATE_STANDBY;  // TODO check if this is necessary
@@ -154,8 +154,8 @@ bool LEQuad::init_main_task(void)
     ret &= scheduler.add_task(4000, (Scheduler_task::task_function_t)&LEQuad::main_task_func, (Scheduler_task::task_argument_t)this, Scheduler_task::PRIORITY_HIGHEST);
 
     // DOWN link
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_NAMED_VALUE_FLOAT,  1000000, (Mavlink_communication::send_msg_function_t)&scheduler_telemetry_send_rt_stats, &scheduler);
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_BIG_DEBUG_VECT,  1000000, (Mavlink_communication::send_msg_function_t)&scheduler_telemetry_send_rt_stats_all, &scheduler);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_NAMED_VALUE_FLOAT,  1000000, (Mavlink_communication::send_msg_function_t)&scheduler_telemetry_send_rt_stats, &scheduler);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_BIG_DEBUG_VECT,  1000000, (Mavlink_communication::send_msg_function_t)&scheduler_telemetry_send_rt_stats_all, &scheduler);
 
     return ret;
 }
@@ -168,11 +168,11 @@ bool LEQuad::init_state(void)
     bool ret = true;
 
     // UP telemetry
-    ret &= state_telemetry_init(&state_machine, mavlink_communication.p_message_handler());
+    ret &= state_telemetry_init(&state_machine, mavlink_communication_.p_message_handler());
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_HEARTBEAT,  1000000, (Mavlink_communication::send_msg_function_t)&state_telemetry_send_heartbeat, &state);
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_SYS_STATUS, 1000000, (Mavlink_communication::send_msg_function_t)&state_telemetry_send_status,    &state);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_HEARTBEAT,  1000000, (Mavlink_communication::send_msg_function_t)&state_telemetry_send_heartbeat, &state);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_SYS_STATUS, 1000000, (Mavlink_communication::send_msg_function_t)&state_telemetry_send_status,    &state);
 
     // Data logging
     ret &= data_logging_stat.add_field((uint32_t*)&state.mav_state_,   "mav_state");
@@ -195,7 +195,7 @@ bool LEQuad::init_communication(void)
     bool ret = true;
 
     // Task
-    ret &= scheduler.add_task(4000,  (Scheduler_task::task_function_t)&Mavlink_communication::update,    (Scheduler_task::task_argument_t)&mavlink_communication);
+    ret &= scheduler.add_task(4000,  (Scheduler_task::task_function_t)&Mavlink_communication::update,    (Scheduler_task::task_argument_t)&mavlink_communication_);
 
     return ret;
 }
@@ -209,8 +209,8 @@ bool LEQuad::init_data_logging(void)
     bool ret = true;
 
     // UP telemetry
-    ret &= data_logging_telemetry_init(&data_logging_continuous, mavlink_communication.p_message_handler());
-    ret &= data_logging_telemetry_init(&data_logging_stat, mavlink_communication.p_message_handler());
+    ret &= data_logging_telemetry_init(&data_logging_continuous, mavlink_communication_.p_message_handler());
+    ret &= data_logging_telemetry_init(&data_logging_stat, mavlink_communication_.p_message_handler());
 
     // Task
     ret &= scheduler.add_task(10000, (Scheduler_task::task_function_t)&task_data_logging_update, (Scheduler_task::task_argument_t)&data_logging_continuous);
@@ -228,10 +228,10 @@ bool LEQuad::init_gps(void)
     bool ret = true;
 
     // UP telemetry
-    ret &= gps_telemetry_init(&gps, mavlink_communication.p_message_handler());
+    ret &= gps_telemetry_init(&gps, mavlink_communication_.p_message_handler());
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_GPS_RAW_INT, 1000000, (Mavlink_communication::send_msg_function_t)&gps_telemetry_send_raw, &gps);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_GPS_RAW_INT, 1000000, (Mavlink_communication::send_msg_function_t)&gps_telemetry_send_raw, &gps);
 
     // Task
     ret &= scheduler.add_task(100000, (Scheduler_task::task_function_t)&task_gps_update, (Scheduler_task::task_argument_t)&gps, Scheduler_task::PRIORITY_HIGH);
@@ -248,24 +248,24 @@ bool LEQuad::init_imu(void)
     bool ret = true;
 
     // UP telemetry
-    ret &= imu_telemetry_init(&imu, mavlink_communication.p_message_handler());
+    ret &= imu_telemetry_init(&imu, mavlink_communication_.p_message_handler());
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_SCALED_IMU, 250000, (Mavlink_communication::send_msg_function_t)&imu_telemetry_send_scaled, &imu);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_SCALED_IMU, 250000, (Mavlink_communication::send_msg_function_t)&imu_telemetry_send_scaled, &imu);
 
     // Parameters
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->gyroscope.bias[X],     "BIAS_GYRO_X");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->gyroscope.bias[Y],     "BIAS_GYRO_Y");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->gyroscope.bias[Z],     "BIAS_GYRO_Z");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->accelerometer.bias[X], "BIAS_ACC_X");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->accelerometer.bias[Y], "BIAS_ACC_Y");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->accelerometer.bias[Z], "BIAS_ACC_Z");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->magnetometer.bias[X],  "BIAS_MAG_X");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->magnetometer.bias[Y],  "BIAS_MAG_Y");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->magnetometer.bias[Z],  "BIAS_MAG_Z");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->magnetic_north[X],     "NORTH_MAG_X");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->magnetic_north[Y],     "NORTH_MAG_Y");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&imu.get_config()->magnetic_north[Z],     "NORTH_MAG_Z");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->gyroscope.bias[X],     "BIAS_GYRO_X");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->gyroscope.bias[Y],     "BIAS_GYRO_Y");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->gyroscope.bias[Z],     "BIAS_GYRO_Z");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->accelerometer.bias[X], "BIAS_ACC_X");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->accelerometer.bias[Y], "BIAS_ACC_Y");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->accelerometer.bias[Z], "BIAS_ACC_Z");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->magnetometer.bias[X],  "BIAS_MAG_X");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->magnetometer.bias[Y],  "BIAS_MAG_Y");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->magnetometer.bias[Z],  "BIAS_MAG_Z");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->magnetic_north[X],     "NORTH_MAG_X");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->magnetic_north[Y],     "NORTH_MAG_Y");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&imu.get_config()->magnetic_north[Z],     "NORTH_MAG_Z");
 
     return ret;
 }
@@ -279,7 +279,7 @@ bool LEQuad::init_barometer(void)
     bool ret = true;
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_SCALED_PRESSURE, 500000, (Mavlink_communication::send_msg_function_t)&barometer_telemetry_send, &barometer);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_SCALED_PRESSURE, 500000, (Mavlink_communication::send_msg_function_t)&barometer_telemetry_send, &barometer);
 
     // Task
     ret &= scheduler.add_task(15000, (Scheduler_task::task_function_t)&task_barometer_update, (Scheduler_task::task_argument_t)&barometer, Scheduler_task::PRIORITY_HIGH);
@@ -296,7 +296,7 @@ bool LEQuad::init_sonar(void)
     bool ret = true;
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_DISTANCE_SENSOR, 200000, (Mavlink_communication::send_msg_function_t)&sonar_telemetry_send, &sonar);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_DISTANCE_SENSOR, 200000, (Mavlink_communication::send_msg_function_t)&sonar_telemetry_send, &sonar);
 
 
     // Task
@@ -314,8 +314,8 @@ bool LEQuad::init_attitude_estimation(void)
     bool ret = true;
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_ATTITUDE,            200000, (Mavlink_communication::send_msg_function_t)&ahrs_telemetry_send_attitude,            &ahrs);
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_ATTITUDE_QUATERNION, 500000, (Mavlink_communication::send_msg_function_t)&ahrs_telemetry_send_attitude_quaternion, &ahrs);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_ATTITUDE,            200000, (Mavlink_communication::send_msg_function_t)&ahrs_telemetry_send_attitude,            &ahrs);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_ATTITUDE_QUATERNION, 500000, (Mavlink_communication::send_msg_function_t)&ahrs_telemetry_send_attitude_quaternion, &ahrs);
 
     return ret;
 }
@@ -328,21 +328,21 @@ bool LEQuad::init_position_estimation(void)
 {
     bool ret = true;
     // UP telemetry
-    ret &= position_estimation_telemetry_init(&position_estimation, mavlink_communication.p_message_handler());
+    ret &= position_estimation_telemetry_init(&position_estimation, mavlink_communication_.p_message_handler());
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_LOCAL_POSITION_NED,  500000, (Mavlink_communication::send_msg_function_t)&position_estimation_telemetry_send_position,        &position_estimation);
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, 250000, (Mavlink_communication::send_msg_function_t)&position_estimation_telemetry_send_global_position, &position_estimation);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_LOCAL_POSITION_NED,  500000, (Mavlink_communication::send_msg_function_t)&position_estimation_telemetry_send_position,        &position_estimation);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_GLOBAL_POSITION_INT, 250000, (Mavlink_communication::send_msg_function_t)&position_estimation_telemetry_send_global_position, &position_estimation);
 
     // Parameters
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_alt_baro,   "POS_KP_ALT_BARO" );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_baro,   "POS_KP_VELB"     );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_pos_gps[0], "POS_KP_POS0"     );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_pos_gps[1], "POS_KP_POS1"     );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_pos_gps[2], "POS_KP_POS2"     );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_gps[0], "POS_KP_VEL0"     );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_gps[1], "POS_KP_VEL1"     );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_gps[2], "POS_KP_VEL2"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_alt_baro,   "POS_KP_ALT_BARO" );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_baro,   "POS_KP_VELB"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_pos_gps[0], "POS_KP_POS0"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_pos_gps[1], "POS_KP_POS1"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_pos_gps[2], "POS_KP_POS2"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_gps[0], "POS_KP_VEL0"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_gps[1], "POS_KP_VEL1"     );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&position_estimation.kp_vel_gps[2], "POS_KP_VEL2"     );
 
     // Data logging
     // ret &= data_logging_continuous.add_field(&position_estimation.local_position.pos[0], "local_x", 3);
@@ -376,7 +376,7 @@ bool LEQuad::init_stabilisers(void)
     ret &= stabilisation_init(&controls);
 
     // Parameters
-    Onboard_parameters& op            = mavlink_communication.onboard_parameters();
+    Onboard_parameters& op            = mavlink_communication_.onboard_parameters();
     stabiliser_t* rate_stabiliser     = &stabilisation_copter.stabiliser_stack.rate_stabiliser;
     stabiliser_t* attitude_stabiliser = &stabilisation_copter.stabiliser_stack.attitude_stabiliser;
     stabiliser_t* velocity_stabiliser = &stabilisation_copter.stabiliser_stack.velocity_stabiliser;
@@ -441,17 +441,17 @@ bool LEQuad::init_navigation(void)
     bool ret = true;
 
     // Parameters
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.dist2vel_gain,                           "NAV_DIST2VEL"    );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.cruise_speed,                            "NAV_CRUISESPEED" );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.max_climb_rate,                          "NAV_CLIMBRATE"   );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.takeoff_altitude,                        "NAV_TAKEOFF_ALT" );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.minimal_radius,                          "NAV_MINI_RADIUS" );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.soft_zone_size,                          "NAV_SOFTZONE"    );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.hovering_controller.p_gain,              "NAV_HOVER_PGAIN" );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.hovering_controller.differentiator.gain, "NAV_HOVER_DGAIN" );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.wpt_nav_controller.p_gain,               "NAV_WPT_PGAIN"   );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.wpt_nav_controller.differentiator.gain,  "NAV_WPT_DGAIN"   );
-    ret &= mavlink_communication.onboard_parameters().add_parameter_float(&navigation.kp_yaw,                                  "NAV_YAW_KPGAIN"  );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.dist2vel_gain,                           "NAV_DIST2VEL"    );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.cruise_speed,                            "NAV_CRUISESPEED" );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.max_climb_rate,                          "NAV_CLIMBRATE"   );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.takeoff_altitude,                        "NAV_TAKEOFF_ALT" );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.minimal_radius,                          "NAV_MINI_RADIUS" );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.soft_zone_size,                          "NAV_SOFTZONE"    );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.hovering_controller.p_gain,              "NAV_HOVER_PGAIN" );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.hovering_controller.differentiator.gain, "NAV_HOVER_DGAIN" );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.wpt_nav_controller.p_gain,               "NAV_WPT_PGAIN"   );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.wpt_nav_controller.differentiator.gain,  "NAV_WPT_DGAIN"   );
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_float(&navigation.kp_yaw,                                  "NAV_YAW_KPGAIN"  );
 
     // Task
     ret &= scheduler.add_task(10000, (Scheduler_task::task_function_t)&Navigation::update,               (Scheduler_task::task_argument_t)&navigation,       Scheduler_task::PRIORITY_HIGH);
@@ -472,7 +472,7 @@ bool LEQuad::init_hud(void)
     ret &= hud_telemetry_init(&hud, &position_estimation, &controls, &ahrs);
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_VFR_HUD, 500000, (Mavlink_communication::send_msg_function_t)&hud_telemetry_send_message, &hud);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_VFR_HUD, 500000, (Mavlink_communication::send_msg_function_t)&hud_telemetry_send_message, &hud);
 
     return ret;
 }
@@ -494,7 +494,7 @@ bool LEQuad::init_servos(void)
     ret &= servos_telemetry_init(&servos_telemetry,
                                  &servo_0, &servo_1, &servo_2, &servo_3,
                                  &servo_4, &servo_5, &servo_6, &servo_7);
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_SERVO_OUTPUT_RAW, 1000000, (Mavlink_communication::send_msg_function_t)&servos_telemetry_mavlink_send, &servos_telemetry);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_SERVO_OUTPUT_RAW, 1000000, (Mavlink_communication::send_msg_function_t)&servos_telemetry_mavlink_send, &servos_telemetry);
 
     return ret;
 }
@@ -508,15 +508,15 @@ bool LEQuad::init_ground_control(void)
     bool ret = true;
 
     // UP telemetry
-    ret &= manual_control_telemetry_init(&manual_control, mavlink_communication.p_message_handler());
+    ret &= manual_control_telemetry_init(&manual_control, mavlink_communication_.p_message_handler());
 
     // DOWN telemetry
-    ret &= mavlink_communication.add_msg_send(MAVLINK_MSG_ID_MANUAL_CONTROL, 500000, (Mavlink_communication::send_msg_function_t)&manual_control_telemetry_send, &manual_control);
+    ret &= mavlink_communication_.add_msg_send(MAVLINK_MSG_ID_MANUAL_CONTROL, 500000, (Mavlink_communication::send_msg_function_t)&manual_control_telemetry_send, &manual_control);
 
     // Parameters
     /* WARNING the following 2 cast are necessary on stm32 architecture, otherwise it leads to execution error */
-    ret &= mavlink_communication.onboard_parameters().add_parameter_int32((int32_t*) &manual_control.control_source_, "CTRL_CTRL_SRC");
-    ret &= mavlink_communication.onboard_parameters().add_parameter_int32((int32_t*) &manual_control.mode_source_,    "COM_RC_IN_MODE");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_int32((int32_t*) &manual_control.control_source_, "CTRL_CTRL_SRC");
+    ret &= mavlink_communication_.onboard_parameters().add_parameter_int32((int32_t*) &manual_control.mode_source_,    "COM_RC_IN_MODE");
 
     // Task
     ret &= scheduler.add_task(20000, (Scheduler_task::task_function_t)&remote_update, (Scheduler_task::task_argument_t)&manual_control.remote, Scheduler_task::PRIORITY_HIGH);

--- a/sample_projects/LEQuad/lequad.hpp
+++ b/sample_projects/LEQuad/lequad.hpp
@@ -167,6 +167,16 @@ public:
      */
     void loop(void);
 
+
+    /**
+     * \brief   Returns non-const reference to MAVLINK Communication
+     * \details This is used to add simulation telemetry from the main function
+     *
+     * \return  MAVLINK Communication module
+     */
+     inline Mavlink_communication& mavlink_communication(){return mavlink_communication_;};
+
+
 protected:
 
     virtual bool init_main_task(void);
@@ -214,7 +224,7 @@ protected:
     State state;                                                ///< The structure with all state information
 
     Scheduler scheduler;
-    Mavlink_communication mavlink_communication;
+    Mavlink_communication mavlink_communication_;
 
     servos_mix_quadcotper_diag_t servo_mix;
 

--- a/sample_projects/LEQuad/main_linux.cpp
+++ b/sample_projects/LEQuad/main_linux.cpp
@@ -42,6 +42,7 @@
 #include "sample_projects/LEQuad/lequad.hpp"
 
 #include "hal/dummy/i2c_dummy.hpp"
+#include "simulation/dynamic_model_telemetry.hpp"
 
 extern "C"
 {
@@ -112,6 +113,12 @@ int main(int argc, char** argv)
                         file_log,
                         file_stat,
                         mav_config);
+
+    // -------------------------------------------------------------------------
+    // Add simulation telemetry
+    // -------------------------------------------------------------------------
+    mav.mavlink_communication().add_msg_send(MAVLINK_MSG_ID_HIL_STATE_QUATERNION,  1000000, (Mavlink_communication::send_msg_function_t)&dynamic_model_telemetry_send_state_quaternion, &board.dynamic_model);
+
 
     print_util_dbg_print("[MAIN] OK. Starting up.\r\n");
 

--- a/simulation/dynamic_model_telemetry.cpp
+++ b/simulation/dynamic_model_telemetry.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file dynamic_model_telemetry.cpp
+ *
+ * \author MAV'RIC Team
+ * \author Basil Huber
+ *
+ * \brief This module takes care of sending periodic telemetric messages for
+ * the dynamic model
+ *
+ ******************************************************************************/
+
+
+#include "simulation/dynamic_model_telemetry.hpp"
+#include "hal/common/time_keeper.hpp"
+#include "util/constants.hpp"
+//#include "util/coord_conventions.hpp"
+
+
+void dynamic_model_telemetry_send_state_quaternion(const Dynamic_model* model, const Mavlink_stream* mavlink_stream, mavlink_message_t* msg)
+{
+      const quat_t attitude_quat = model->attitude();
+      const float attitude[4] = {attitude_quat.s, attitude_quat.v[X], attitude_quat.v[Y], attitude_quat.v[Z]};
+      const std::array<float, 3>& rate = model->angular_velocity_bf();
+      const global_position_t& position = model->position_gf();
+      const std::array<float, 3>& velocity = model->velocity_lf();
+      const uint16_t speed = vectors_norm(velocity.data());
+      const std::array<float, 3>& acc = model->acceleration_bf();
+
+      mavlink_msg_hil_state_quaternion_pack(mavlink_stream->sysid(),
+                                          mavlink_stream->compid(),
+                                          msg,
+                                          time_keeper_get_ms(),                     // Timestamp (microseconds since UNIX epoch or microseconds since system boot)
+                                          attitude,                                 // attitude_quaternion Vehicle attitude expressed as normalized quaternion in w, x, y, z order (with 1 0 0 0 being the null-rotation)
+                                          rate[ROLL],                               // Body frame roll / phi angular speed (rad/s)
+                                          rate[PITCH],                              // Body frame pitch / theta angular speed (rad/s)
+                                          rate[YAW],                                // Body frame yaw / psi angular speed (rad/s)
+                                          (int32_t)(position.latitude  * 1e7),      // Latitude, expressed as * 1E7
+                                          (int32_t)(position.longitude * 1e7),      // Longitude, expressed as * 1E7,      //
+                                          (int32_t)(position.altitude  * 1e3),      // Altitude in meters, expressed as * 1000 (millimeters)
+                                          (int16_t)(velocity[X] * 1e2),             // Ground X Speed (Latitude), expressed as m/s * 100
+                                          (int16_t)(velocity[Y] * 1e2),             // Ground Y Speed (Longitude), expressed as m/s * 100
+                                          (int16_t)(velocity[Z] * 1e2),             // Ground Z Speed (Altitude), expressed as m/s * 100
+                                          (uint16_t)(speed * 1e2),                  // Indicated airspeed, expressed as m/s * 100 [CURRENTLY NORM OF VELOCITY]
+                                          (uint16_t)(speed * 1e2),                  // True airspeed, expressed as m/s * 100     [CURRENTLY NORM OF VELOCITY]
+                                          (int16_t)(acc[X] * 1e3 * GRAVITY),        // X acceleration (mg) [BODY FRAME]
+                                          (int16_t)(acc[Y] * 1e3 * GRAVITY),        // Y acceleration (mg) [BODY FRAME]
+                                          (int16_t)(acc[Z] * 1e3 * GRAVITY));       // Z acceleration (mg) [BODY FRAME]
+}

--- a/simulation/dynamic_model_telemetry.hpp
+++ b/simulation/dynamic_model_telemetry.hpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2009-2016, MAV'RIC Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ * \file dynamic_model_telemetry.hpp
+ *
+ * \author MAV'RIC Team
+ * \author Basil Huber
+ *
+ * \brief This module takes care of sending periodic telemetric messages for
+ * the dynamic model
+ *
+ ******************************************************************************/
+
+
+#ifndef DYNAMIC_MODEL_TELEMETRY_HPP_
+#define DYNAMIC_MODEL_TELEMETRY_HPP_
+
+#include "communication/mavlink_stream.hpp"
+#include "simulation/dynamic_model.hpp"
+
+
+/**
+ * \brief   Function to send the MAVLink HIL_STATE_QUATERNION message sending the groundtruth of the simulation
+ *
+ * \details true airspeed and indicated airspeed currently equal ground speed
+ *
+ * \param   dynamic_model           Dynamic model of the simulation
+ * \param   mavlink_stream          The pointer to the MAVLink stream structure
+ * \param   msg                     The pointer to the MAVLink message
+ */
+void dynamic_model_telemetry_send_state_quaternion(const Dynamic_model* model, const Mavlink_stream* mavlink_stream, mavlink_message_t* msg);
+
+#endif /* DYNAMIC_MODEL_TELEMETRY_HPP_ */


### PR DESCRIPTION
- LEQuad:
+ added mavlink_communication() function to return non-const ref to mavlink_communication
+ changed member variable: mavlink_communication -> mavlink_communication_

- Dynamic_mode_telemetry: created files and add functions to send hil_state_quaternion message

- main_linux.cpp: added registering of hil_state_quaternion message