### PR TITLE
Default sysid 1

### DIFF
--- a/sample_projects/LEQuad/main_linux.cpp
+++ b/sample_projects/LEQuad/main_linux.cpp
@@ -52,7 +52,7 @@ extern "C"
 
 int main(int argc, char** argv)
 {
-    uint8_t sysid = 0;
+    uint8_t sysid = 1;
     bool init_success = true;
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
QGroundControl 3.0 does not connect to drones with system ID 0.