### PR TITLE
Add reading of factory calibrated parameters in the driver of BMP085

### DIFF
--- a/drivers/barometer_bmp085.cpp
+++ b/drivers/barometer_bmp085.cpp
@@ -96,7 +96,7 @@ Barometer_BMP085::Barometer_BMP085(I2c& i2c):
     ac4_(32741),
     ac5_(32757),
     ac6_(23153),
-    mb_(1),     // TODO check value in datasheet
+    mb_(-32768),
     mc_(-8711),
     md_(2868),
     b1_(6190),
@@ -126,11 +126,45 @@ bool Barometer_BMP085::init(void)
     // Test if the sensor if here
     res &= i2c_.probe(BMP085_SLAVE_ADDRESS);
 
+    // Read calibration data
+    res &= read_eprom_calibration();
+
     // Reset Barometer_BMP085 state
     state_ = BMP085_IDLE;
 
     return res;
 }
+
+
+bool Barometer_BMP085::read_eprom_calibration(void)
+{
+    bool res = true;
+
+    uint8_t start_address = BMP085_CAL_AC1;
+    uint8_t buffer[22];
+
+    // Read EPROM
+    res &= i2c_.write(&start_address, 1, BMP085_SLAVE_ADDRESS);
+    res &= i2c_.read(buffer, 22, BMP085_SLAVE_ADDRESS);
+
+    if (res)
+    {
+        ac1_ = (int16_t)(buffer[0] << 8 | buffer[1]);
+        ac2_ = (int16_t)(buffer[2] << 8 | buffer[3]);
+        ac3_ = (int16_t)(buffer[4] << 8 | buffer[5]);
+        ac4_ = (uint16_t)(buffer[6] << 8 | buffer[7]);
+        ac5_ = (uint16_t)(buffer[8] << 8 | buffer[9]);
+        ac6_ = (uint16_t)(buffer[10] << 8 | buffer[11]);
+        b1_  = (int16_t)(buffer[12] << 8 | buffer[13]);
+        b2_  = (int16_t)(buffer[14] << 8 | buffer[15]);
+        mb_  = (int16_t)(buffer[16] << 8 | buffer[17]);
+        mc_  = (int16_t)(buffer[18] << 8 | buffer[19]);
+        md_  = (int16_t)(buffer[20] << 8 | buffer[21]);
+    }
+
+    return res;
+}
+
 
 
 bool Barometer_BMP085::update(void)

--- a/drivers/barometer_bmp085.hpp
+++ b/drivers/barometer_bmp085.hpp
@@ -85,6 +85,14 @@ public:
 
 
     /**
+     * \brief   Read calibration data from EPROM
+     *
+     * \return  Success
+     */
+    bool read_eprom_calibration(void);
+
+
+    /**
      * \brief   Main update function
      * \detail  Reads new values from sensor
      *
@@ -135,7 +143,7 @@ public:
      */
     float temperature(void) const;
 
-    
+
 private:
     I2c&        i2c_;                   ///< Reference to I2C peripheral
 

--- a/drivers/barometer_telemetry.cpp
+++ b/drivers/barometer_telemetry.cpp
@@ -54,7 +54,7 @@ void barometer_telemetry_send(const Barometer* barometer, const Mavlink_stream* 
                                      mavlink_stream->compid(),
                                      msg,
                                      time_keeper_get_ms(),
+                                     barometer->pressure(),
                                      barometer->altitude_gf(),
-                                     barometer->vertical_speed_lf(),
                                      barometer->temperature());
 }


### PR DESCRIPTION
Fixes #327 

In the driver of the baro BMP085, the calibration data (used to compute pressure from raw sensor data) were the example values given in the datasheet. I added a method to read the calibration data from EPROM. This method is called in the init function.

Before the change, I got raw pressure of about 129 119hPa, which translates to an estimated altitude of -2092m with sea level pressure of 101 325hPa. Now, I get a pressure of 97 960hPa, which gives an altitude of 284m. This is still much closer to reality !