### PR TITLE
Added check in scheduler for 0 tasks

### DIFF
--- a/runtime/scheduler.cpp
+++ b/runtime/scheduler.cpp
@@ -106,37 +106,40 @@ int32_t Scheduler::update(void)
     int32_t realtime_violation = 0;
 
     // Iterate through registered tasks
-    uint32_t i = current_schedule_slot_;
-    do
+    if (task_count_ > 0)
     {
-        // If the task is active and has waited long enough...
-        if (tasks()[i].is_due())
+        uint32_t i = current_schedule_slot_;
+        do
         {
-            // Execute task
-            if (!tasks()[i].execute())
+            // If the task is active and has waited long enough...
+            if (tasks()[i].is_due())
             {
-                realtime_violation++; //realtime violation!!
+                // Execute task
+                if (!tasks()[i].execute())
+                {
+                    realtime_violation++; //realtime violation!!
+                }
+
+                // Depending on shceduling strategy, select next task slot
+                switch (schedule_strategy_)
+                {
+                    case FIXED_PRIORITY:
+                        // Fixed priority scheme - scheduler will start over with tasks with the highest priority
+                        current_schedule_slot_ = 0;
+                        break;
+
+                    case ROUND_ROBIN:
+                        // Round robin scheme - scheduler will pick up where it left.
+                        current_schedule_slot_ = (current_schedule_slot_+1)%task_count_;
+                        break;
+                }
+
+                return realtime_violation;
             }
+            i = (i+1)%task_count_;
 
-            // Depending on shceduling strategy, select next task slot
-            switch (schedule_strategy_)
-            {
-                case FIXED_PRIORITY:
-                    // Fixed priority scheme - scheduler will start over with tasks with the highest priority
-                    current_schedule_slot_ = 0;
-                    break;
-
-                case ROUND_ROBIN:
-                    // Round robin scheme - scheduler will pick up where it left.
-                    current_schedule_slot_ = (current_schedule_slot_+1)%task_count_;
-                    break;
-            }
-
-            return realtime_violation;
-        }
-        i = (i+1)%task_count_;
-
-    } while(i != current_schedule_slot_);
+        } while(i != current_schedule_slot_);
+    }
 
     return realtime_violation;
 }


### PR DESCRIPTION
Added check to only attempt to execute tasks if there are any. 

This is needed if there are callback functions but no outgoing telemetry messages. For example, with my raspberry pi, I receive mavlink messages on MAVRIC from the raspi but do not need to periodically send messages to the raspi. As [this Mavlink_communication::update() line](https://github.com/lis-epfl/MAVRIC_Library/blob/258aab6ce0e8fd5f5043221094cc5a6c34e22755/communication/mavlink_communication.hpp#L173) calls the scheduler to execute tasks, a floating point exception will be thrown if it is empty.